### PR TITLE
chore: CI, install tests, and PR workflow for develop

### DIFF
--- a/.github/helpers/install.sh
+++ b/.github/helpers/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+cd ~ || exit 1
+
+sudo apt-get update
+sudo apt-get install -y redis-server mariadb-client libmariadb-dev pkg-config
+
+pip install frappe-bench
+
+FRAPPE_BRANCH="${FRAPPE_BRANCH:-version-15}"
+
+bench init --skip-assets --frappe-branch "${FRAPPE_BRANCH}" --python "$(which python)" frappe-bench
+
+mkdir -p ~/frappe-bench/sites/test_site
+cp "${GITHUB_WORKSPACE}/.github/helpers/site_config_mariadb.json" \
+	~/frappe-bench/sites/test_site/site_config.json
+
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE USER IF NOT EXISTS 'test_frappe'@'%' IDENTIFIED BY 'test_frappe'"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE DATABASE IF NOT EXISTS test_frappe"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "GRANT ALL PRIVILEGES ON \`test_frappe\`.* TO 'test_frappe'@'%'"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "FLUSH PRIVILEGES"
+
+cd ~/frappe-bench || exit 1
+
+# Disable background workers in CI
+sed -i 's/watch:/# watch:/g' Procfile || true
+sed -i 's/schedule:/# schedule:/g' Procfile || true
+sed -i 's/socketio:/# socketio:/g' Procfile || true
+sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile || true
+
+bench get-app saral_hr "${GITHUB_WORKSPACE}"
+bench setup requirements --dev
+
+bench start &>> ~/frappe-bench/bench_start.log &
+CI=Yes bench build --app frappe &
+bench --site test_site reinstall --yes
+bench --verbose --site test_site install-app saral_hr

--- a/.github/helpers/site_config_mariadb.json
+++ b/.github/helpers/site_config_mariadb.json
@@ -1,0 +1,11 @@
+{
+	"db_host": "127.0.0.1",
+	"db_port": 3306,
+	"db_name": "test_frappe",
+	"db_password": "test_frappe",
+	"admin_password": "admin",
+	"root_login": "root",
+	"root_password": "root",
+	"host_name": "http://test_site:8000",
+	"developer_mode": 1
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+concurrency:
+  group: ci-saral-hr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Server Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    services:
+      mysql:
+        image: mariadb:10.6
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MARIADB_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=5s --health-retries=10
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check Python syntax and merge conflicts
+        run: |
+          python -m compileall -q -f "${GITHUB_WORKSPACE}/saral_hr"
+          if grep -lr --exclude-dir=.git --exclude-dir=node_modules "^<<<<<<< " "${GITHUB_WORKSPACE}"; then
+            echo "Found merge conflicts"
+            exit 1
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Add test_site to hosts
+        run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install bench and site
+        run: bash "${GITHUB_WORKSPACE}/.github/helpers/install.sh"
+        env:
+          FRAPPE_BRANCH: version-15
+
+      - name: Run Saral HR tests
+        run: |
+          cd ~/frappe-bench
+          bench --site test_site run-tests --app saral_hr --module saral_hr.tests.test_install
+
+  success:
+    name: Success
+    needs: tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check result
+        run: |
+          if [ "${{ needs.tests.result }}" != "success" ]; then
+            echo "Required job failed: tests=${{ needs.tests.result }}"
+            exit 1
+          fi
+          echo "CI Success"

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 tags
 node_modules
 __pycache__
-.github/
 .cursor/
 .agents/
 skills-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+## About 
+
+Saral HR, is a attendance, payroll and employee management app build on Frappe Framework and Frappe UI (VueJS).
+
+## IMPORTANT
+
+Always load and user frappe-app-dev skills.
+
+## Development Details
+
+Unless mentioned, the site is saral.localhost with administrator/admin credentials.
+
+## Planning / Spec-ing
+
+Use Tracer bullets comes from the Pragmatic Programmer. When building systems, you want to write code that gets you feedback as quickly as possible. Tracer bullets are small slices of functionality that go through all layers of the system, allowing you to test and validate your approach early. This helps in identifying potential issues and ensures that the overall architecture is sound before investing significant time in development.
+
+## Implementation Guidelines
+
+* Create a new branch before working on a new feature/spec (branch name patterns: feat/, fix/, just like conventional commit pre-fixes)
+* Never commit directly to `develop` — open a PR against `develop`
+* Reconcile the spec and log the progress after each phase of development
+* Commit after each meaningful phase
+* Commit the spec before the development commits
+* Use comments only when necessary to explain "why?" not "how?", how must be clear from the code itself
+
+## Frontend / Backend Sync
+
+* Whenever a new field is added to a backend DocType that is surfaced in the frontend (e.g. settings panels), it must also be handled in the corresponding frontend component so the two stay in sync. This is a convention/reminder only — there is no automatic syncing mechanism; the frontend enumerates fields explicitly.
+
+## Regression tests
+
+* When we fix a bug, add at the very least a Unit test, and verify before/after by temp revert of fix to make sure the test tests what is intended
+* For bigger features/workflows, e2e playwright tests are a must.
+* Local: `bench --site saral.localhost run-tests --app saral_hr` (prefer a dedicated test site when available)
+* CI: GitHub Actions workflow `.github/workflows/ci.yml` runs on every PR to `develop`
+
+## Pull Requests
+
+* Raise PR always against the develop branch
+* Wait for CI (`CI / Success`) to pass before merging
+* Keep pull request descriptions stupid simple
+* Some formats:
+    1. h2 Problem (1-2 sentences), h2 Solution: good for bugs, etc.
+    2. h2 Why? h2 What? h2 How?: good for new features and enhancements
+
+## Branch protection
+
+* `develop` is protected: PRs required, CI must pass, no direct pushes
+* Use `feat/` or `fix/` branches for all work

--- a/README.md
+++ b/README.md
@@ -40,3 +40,17 @@ if frappe.is_setup_complete():
 Then hard-refresh the browser (or clear site data) and log in again.
 
 **Install tip:** Prefer completing the Frappe Setup Wizard (or confirming Desk opens) before installing `saral_hr` on a brand-new site.
+
+## Contributing
+
+1. Branch from `develop` using `feat/` or `fix/` prefixes.
+2. Add/update tests for the change.
+3. Open a PR against `develop` (direct pushes to `develop` are blocked).
+4. Merge only after CI (`CI / Success`) passes.
+
+Local check for the install guard:
+
+```bash
+bench --site saral.localhost set-config allow_tests true
+bench --site saral.localhost run-tests --app saral_hr --module saral_hr.tests.test_install
+```

--- a/saral_hr/tests/__init__.py
+++ b/saral_hr/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package for Saral HR

--- a/saral_hr/tests/test_install.py
+++ b/saral_hr/tests/test_install.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026, sj and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from saral_hr.install import ensure_desk_home_consistent
+
+
+class TestInstall(FrappeTestCase):
+	def setUp(self):
+		self._prev_home = frappe.db.get_default("desktop:home_page")
+		self._prev_setup_default = frappe.db.get_default("setup_complete")
+
+	def tearDown(self):
+		if self._prev_home is not None:
+			frappe.db.set_default("desktop:home_page", self._prev_home)
+		if self._prev_setup_default is not None:
+			frappe.db.set_default("setup_complete", self._prev_setup_default)
+		frappe.clear_cache()
+
+	def test_ensure_desk_home_consistent_fixes_setup_wizard_loop_state(self):
+		"""Broken combo: setup complete + home still setup-wizard must be repaired."""
+		if not frappe.is_setup_complete():
+			self.skipTest("Site setup is not complete; cannot assert repair path")
+
+		frappe.db.set_default("desktop:home_page", "setup-wizard")
+		frappe.db.set_default("setup_complete", "0")
+
+		ensure_desk_home_consistent()
+
+		self.assertEqual(frappe.db.get_default("desktop:home_page"), "workspace")
+		self.assertEqual(str(frappe.db.get_default("setup_complete")), "1")
+
+	def test_ensure_desk_home_consistent_noop_when_setup_incomplete(self):
+		"""Must not flip home away from setup-wizard while setup is incomplete."""
+		# Force the early-return path without mutating Installed Application rows.
+		original = frappe.is_setup_complete
+		frappe.is_setup_complete = lambda: False
+		try:
+			frappe.db.set_default("desktop:home_page", "setup-wizard")
+			ensure_desk_home_consistent()
+			self.assertEqual(frappe.db.get_default("desktop:home_page"), "setup-wizard")
+		finally:
+			frappe.is_setup_complete = original


### PR DESCRIPTION
## Why?

`develop` had no CI, no branch protection, and AGENTS.md required PR + tests that were not enforced.

## What?

- GitHub Actions CI for PRs to `develop` (Frappe v15 + Saral HR install guard tests)
- Unit tests for `ensure_desk_home_consistent` (verified fail without fix / pass with fix)
- AGENTS.md + README contribution rules: branch from `develop`, PR required, wait for CI
- Stop ignoring `.github/` in `.gitignore` so workflows can be versioned

## How?

CI job installs a temporary bench, installs `saral_hr`, runs `saral_hr.tests.test_install`. Branch protection on `develop` will require PRs + `CI / Success`.

Note: the desk refresh-loop fix itself is already on `develop` (`50abe89`); this PR adds the missing test + process enforcement around it.

Made with [Cursor](https://cursor.com)