### PR TITLE
feat: Company list Staff / Worker / Total headcount

### DIFF
--- a/saral_hr/patches.txt
+++ b/saral_hr/patches.txt
@@ -5,3 +5,4 @@
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 saral_hr.patches.set_pdf_options
+saral_hr.patches.backfill_company_employee_counts

--- a/saral_hr/patches/backfill_company_employee_counts.py
+++ b/saral_hr/patches/backfill_company_employee_counts.py
@@ -1,0 +1,10 @@
+import frappe
+
+from saral_hr.saral_hr.doctype.company.company import backfill_all_company_employee_counts
+
+
+def execute():
+	"""One-time backfill of Company headcount fields from active Company Links."""
+	if not frappe.db.has_column("Company", "no_of_staff"):
+		return
+	backfill_all_company_employee_counts()

--- a/saral_hr/saral_hr/doctype/company/company.json
+++ b/saral_hr/saral_hr/doctype/company/company.json
@@ -16,11 +16,6 @@
   "column_break_opgj",
   "country",
   "default_currency",
-  "headcount_section",
-  "no_of_staff",
-  "no_of_workers",
-  "column_break_headcount",
-  "total_no_of_employees",
   "contact_address_section",
   "phone_no",
   "email",
@@ -51,7 +46,12 @@
   "section_esic_components",
   "esic_dependent_component",
   "section_pf_components",
-  "pf_dependent_component"
+  "pf_dependent_component",
+  "headcount_tab",
+  "no_of_staff",
+  "no_of_workers",
+  "column_break_headcount",
+  "total_no_of_employees"
  ],
  "fields": [
   {
@@ -100,42 +100,6 @@
    "label": "Default Currency",
    "options": "Currency",
    "reqd": 1
-  },
-  {
-   "fieldname": "headcount_section",
-   "fieldtype": "Section Break",
-   "label": "Headcount"
-  },
-  {
-   "default": "0",
-   "fieldname": "no_of_staff",
-   "fieldtype": "Int",
-   "in_list_view": 1,
-   "label": "Staff",
-   "non_negative": 1,
-   "read_only": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "no_of_workers",
-   "fieldtype": "Int",
-   "in_list_view": 1,
-   "label": "Worker",
-   "non_negative": 1,
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_headcount",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "total_no_of_employees",
-   "fieldtype": "Int",
-   "in_list_view": 1,
-   "label": "Total",
-   "non_negative": 1,
-   "read_only": 1
   },
   {
    "fieldname": "contact_address_section",
@@ -297,6 +261,42 @@
    "fieldtype": "Table",
    "label": "PF Periods",
    "options": "Statutory Wage Component"
+  },
+  {
+   "fieldname": "headcount_tab",
+   "fieldtype": "Tab Break",
+   "label": "Headcount"
+  },
+  {
+   "default": "0",
+   "fieldname": "no_of_staff",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Staff",
+   "non_negative": 1,
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "no_of_workers",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Worker",
+   "non_negative": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_headcount",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "total_no_of_employees",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Total",
+   "non_negative": 1,
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/saral_hr/saral_hr/doctype/company/company.json
+++ b/saral_hr/saral_hr/doctype/company/company.json
@@ -16,6 +16,11 @@
   "column_break_opgj",
   "country",
   "default_currency",
+  "headcount_section",
+  "no_of_staff",
+  "no_of_workers",
+  "column_break_headcount",
+  "total_no_of_employees",
   "contact_address_section",
   "phone_no",
   "email",
@@ -62,7 +67,6 @@
   {
    "fieldname": "company",
    "fieldtype": "Data",
-   "in_list_view": 1,
    "label": "Company",
    "reqd": 1,
    "unique": 1
@@ -85,7 +89,6 @@
   {
    "fieldname": "country",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "Country",
    "options": "Country",
    "reqd": 1
@@ -97,6 +100,42 @@
    "label": "Default Currency",
    "options": "Currency",
    "reqd": 1
+  },
+  {
+   "fieldname": "headcount_section",
+   "fieldtype": "Section Break",
+   "label": "Headcount"
+  },
+  {
+   "default": "0",
+   "fieldname": "no_of_staff",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "No of Staff",
+   "non_negative": 1,
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "no_of_workers",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "No of Workers",
+   "non_negative": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_headcount",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "total_no_of_employees",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Total No of Employees",
+   "non_negative": 1,
+   "read_only": 1
   },
   {
    "fieldname": "contact_address_section",
@@ -294,5 +333,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "company"
 }

--- a/saral_hr/saral_hr/doctype/company/company.json
+++ b/saral_hr/saral_hr/doctype/company/company.json
@@ -111,7 +111,7 @@
    "fieldname": "no_of_staff",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "No of Staff",
+   "label": "Staff",
    "non_negative": 1,
    "read_only": 1
   },
@@ -120,7 +120,7 @@
    "fieldname": "no_of_workers",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "No of Workers",
+   "label": "Worker",
    "non_negative": 1,
    "read_only": 1
   },
@@ -133,7 +133,7 @@
    "fieldname": "total_no_of_employees",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Total No of Employees",
+   "label": "Total",
    "non_negative": 1,
    "read_only": 1
   },

--- a/saral_hr/saral_hr/doctype/company/company.py
+++ b/saral_hr/saral_hr/doctype/company/company.py
@@ -10,6 +10,42 @@ from frappe.utils import flt, getdate
 VIRTUAL_COMPONENTS = {"Gross", "Gross Including Additional Salary"}
 
 
+def update_company_employee_counts(company: str | None) -> None:
+	"""Recount active Staff/Worker Company Links onto Company headcount fields."""
+	if not company or not frappe.db.exists("Company", company):
+		return
+
+	rows = frappe.db.sql(
+		"""
+		SELECT category, COUNT(*) AS cnt
+		FROM `tabCompany Link`
+		WHERE company = %s AND IFNULL(is_active, 0) = 1
+		GROUP BY category
+		""",
+		company,
+		as_dict=True,
+	)
+	by_cat = {r.category: int(r.cnt) for r in rows}
+	staff = by_cat.get("Staff", 0)
+	workers = by_cat.get("Worker", 0)
+
+	frappe.db.set_value(
+		"Company",
+		company,
+		{
+			"no_of_staff": staff,
+			"no_of_workers": workers,
+			"total_no_of_employees": staff + workers,
+		},
+		update_modified=False,
+	)
+
+
+def backfill_all_company_employee_counts() -> None:
+	for name in frappe.get_all("Company", pluck="name"):
+		update_company_employee_counts(name)
+
+
 class Company(Document):
 
     def validate(self):

--- a/saral_hr/saral_hr/doctype/company/company_list.js
+++ b/saral_hr/saral_hr/doctype/company/company_list.js
@@ -1,0 +1,3 @@
+frappe.listview_settings["Company"] = {
+	hide_name_column: true,
+};

--- a/saral_hr/saral_hr/doctype/company/test_company.py
+++ b/saral_hr/saral_hr/doctype/company/test_company.py
@@ -1,9 +1,173 @@
 # Copyright (c) 2026, sj and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import getdate
+
+from saral_hr.saral_hr.doctype.company.company import (
+	backfill_all_company_employee_counts,
+	update_company_employee_counts,
+)
 
 
-class TestCompany(FrappeTestCase):
-	pass
+def _ensure_category(name: str, has_subtype: int = 0):
+	if frappe.db.exists("Category", name):
+		return name
+	doc = frappe.get_doc(
+		{
+			"doctype": "Category",
+			"category": name,
+			"has_subtype": has_subtype,
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _uid() -> str:
+	return frappe.generate_hash(length=6)
+
+
+def _make_company() -> str:
+	uid = _uid()
+	doc = frappe.get_doc(
+		{
+			"doctype": "Company",
+			"company": f"_Test Co Counts {uid}",
+			"abbr": f"C{uid}"[:8],
+			"country": "India",
+			"default_currency": "INR",
+			"salary_calculation_based_on": "Exclude Weekly Offs (Working Days)",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_employee() -> str:
+	doc = frappe.get_doc(
+		{
+			"doctype": "Employee",
+			"naming_series": "HR-EMP-",
+			"first_name": f"CountEmp{_uid()}",
+			"gender": "Other",
+			"date_of_birth": "1990-01-01",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_company_link(
+	employee: str,
+	company: str,
+	category: str,
+	*,
+	is_active: int = 1,
+	skill_type: str | None = None,
+):
+	doc = frappe.get_doc(
+		{
+			"doctype": "Company Link",
+			"employee": employee,
+			"company": company,
+			"category": category,
+			"date_of_joining": getdate(),
+			"is_active": is_active,
+			"skill_type": skill_type or "",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+def _counts(company: str) -> tuple[int, int, int]:
+	row = frappe.db.get_value(
+		"Company",
+		company,
+		["no_of_staff", "no_of_workers", "total_no_of_employees"],
+		as_dict=True,
+	)
+	return (
+		int(row.no_of_staff or 0),
+		int(row.no_of_workers or 0),
+		int(row.total_no_of_employees or 0),
+	)
+
+
+class TestCompanyEmployeeCounts(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_category("Staff", has_subtype=0)
+		_ensure_category("Worker", has_subtype=1)
+		_ensure_category("Contractor", has_subtype=0)
+
+	def test_active_staff_and_worker_increment_counts(self):
+		company = _make_company()
+		_make_company_link(_make_employee(), company, "Staff")
+		_make_company_link(_make_employee(), company, "Worker", skill_type="Skilled")
+
+		self.assertEqual(_counts(company), (1, 1, 2))
+
+	def test_inactive_links_excluded(self):
+		company = _make_company()
+		link = _make_company_link(_make_employee(), company, "Staff")
+		self.assertEqual(_counts(company), (1, 0, 1))
+
+		link.is_active = 0
+		link.save(ignore_permissions=True)
+		self.assertEqual(_counts(company), (0, 0, 0))
+
+	def test_other_categories_do_not_affect_total(self):
+		company = _make_company()
+		_make_company_link(_make_employee(), company, "Staff")
+		_make_company_link(_make_employee(), company, "Contractor")
+
+		self.assertEqual(_counts(company), (1, 0, 1))
+
+	def test_trash_decreases_counts(self):
+		company = _make_company()
+		link = _make_company_link(
+			_make_employee(), company, "Worker", skill_type="Unskilled"
+		)
+		self.assertEqual(_counts(company), (0, 1, 1))
+
+		link.delete(ignore_permissions=True)
+		self.assertEqual(_counts(company), (0, 0, 0))
+
+	def test_company_change_moves_counts(self):
+		company_a = _make_company()
+		company_b = _make_company()
+		link = _make_company_link(_make_employee(), company_a, "Staff")
+		self.assertEqual(_counts(company_a), (1, 0, 1))
+		self.assertEqual(_counts(company_b), (0, 0, 0))
+
+		link.company = company_b
+		link.save(ignore_permissions=True)
+		self.assertEqual(_counts(company_a), (0, 0, 0))
+		self.assertEqual(_counts(company_b), (1, 0, 1))
+
+	def test_backfill_recomputes_counts(self):
+		company = _make_company()
+		_make_company_link(_make_employee(), company, "Staff")
+
+		frappe.db.set_value(
+			"Company",
+			company,
+			{
+				"no_of_staff": 99,
+				"no_of_workers": 99,
+				"total_no_of_employees": 99,
+			},
+			update_modified=False,
+		)
+		self.assertEqual(_counts(company), (99, 99, 99))
+
+		backfill_all_company_employee_counts()
+		self.assertEqual(_counts(company), (1, 0, 1))
+
+	def test_helper_noop_for_missing_company(self):
+		update_company_employee_counts(None)
+		update_company_employee_counts("_Does Not Exist Counts Co")

--- a/saral_hr/saral_hr/doctype/company_link/company_link.py
+++ b/saral_hr/saral_hr/doctype/company_link/company_link.py
@@ -3,6 +3,8 @@ import datetime
 from frappe.model.document import Document
 from frappe import _
 
+from saral_hr.saral_hr.doctype.company.company import update_company_employee_counts
+
 
 class CompanyLink(Document):
 
@@ -96,6 +98,9 @@ class CompanyLink(Document):
         })
         frappe.db.commit()
 
+        # SQL update bypasses Document hooks — recount the previous company
+        update_company_employee_counts(old_record["company"])
+
         frappe.msgprint(
             _("Employee {0} has been transferred from {1} to {2}. "
               "Previous record archived as {3} with leaving date {4}.").format(
@@ -138,12 +143,26 @@ class CompanyLink(Document):
 
     def after_insert(self):
         self._safe_sync()
+        update_company_employee_counts(self.company)
 
     def on_update(self):
         self._safe_sync()
+        self._recount_companies()
 
     def on_trash(self):
         self._safe_sync()
+
+    def after_delete(self):
+        # Count after delete so this row is not still included
+        update_company_employee_counts(self.company)
+
+    def _recount_companies(self):
+        companies = {self.company}
+        before = self.get_doc_before_save()
+        if before and before.company and before.company != self.company:
+            companies.add(before.company)
+        for company in companies:
+            update_company_employee_counts(company)
 
     def _safe_sync(self):
         try:

--- a/specs/001-company-list-employee-counts.md
+++ b/specs/001-company-list-employee-counts.md
@@ -98,3 +98,4 @@ No Playwright for this spec.
 |------|------|
 | 2026-07-18 | Spec written after grilling; status `planned` |
 | 2026-07-18 | Implemented on `feat/company-list-employee-counts`: Company fields, recount helper, Company Link hooks (`after_delete` used instead of recount-in-`on_trash` so the deleted row is excluded), transfer SQL path recounts old company, backfill patch, unit tests (7) green |
+| 2026-07-18 | Fix double name: `title_field` + no `in_list_view` on `company` were not enough — Frappe still appends an ID column when title_field ≠ name; added `company_list.js` with `hide_name_column: true` |

--- a/specs/001-company-list-employee-counts.md
+++ b/specs/001-company-list-employee-counts.md
@@ -1,0 +1,100 @@
+# 001 — Company list employee counts
+
+| | |
+|---|---|
+| **Status** | done |
+| **Branch** | `feat/company-list-employee-counts` |
+| **Primary DocTypes** | Company, Company Link |
+
+## Why?
+
+Company list view should show headcount at a glance (staff, workers, total) without opening each company or running a report. Counts come from Company Link and must stay correct as employment links change.
+
+## What?
+
+On the **Company** Desk list (and a small read-only section on the Company form), show three columns/fields:
+
+1. **No of Staff**
+2. **No of Workers**
+3. **Total No of Employees** (= Staff + Workers)
+
+Also fix the duplicate company name on the list (ID + Company field both showing the same value).
+
+## How?
+
+### Data model (Company)
+
+Add three **Int** fields, read-only:
+
+| Fieldname | Label | Notes |
+|-----------|-------|--------|
+| `no_of_staff` | No of Staff | `in_list_view` |
+| `no_of_workers` | No of Workers | `in_list_view` |
+| `total_no_of_employees` | Total No of Employees | `in_list_view` |
+
+Place them in a read-only **Headcount** section on the Company **Details** tab (near company / country).
+
+### List view layout
+
+- Show: primary company title + the three count columns
+- **Remove** `in_list_view` from `country` (still on form)
+- **Remove** `in_list_view` from the `company` Data field (avoids double name)
+- Set `title_field` to `company` so the list/title uses the company name once
+
+### Count rules
+
+Source: `Company Link` where `company` = this Company.
+
+| Rule | Decision |
+|------|----------|
+| Active filter | Only `is_active = 1` |
+| Staff | `category == "Staff"` |
+| Workers | `category == "Worker"` |
+| Total | Staff + Workers only (ignore other categories) |
+| Category matching | Hardcoded names `"Staff"` / `"Worker"` (same as Company Enrollment Summary) |
+
+### Sync
+
+1. Shared helper, e.g. `update_company_employee_counts(company: str)`, that:
+   - Aggregates active Company Links by category
+   - Writes the three Int fields via `frappe.db.set_value(..., update_modified=False)`
+2. Call from **Company Link** on `after_insert`, `on_update`, `on_trash`
+3. If `company` changes on update, recalculate **both** old and new company
+4. **Backfill patch** (one-time on migrate) for all existing companies so counts are not stuck at 0 after deploy
+
+### Tests (unit only)
+
+Cover the helper + hooks:
+
+- Active Staff / Worker increment the right fields; Total = sum
+- `is_active = 0` excluded
+- Other categories do not affect Total
+- Trash / deactivate decreases counts
+- Changing `company` on a link moves counts from old → new company
+
+No Playwright for this spec.
+
+### Out of scope
+
+- Changing Company Enrollment Summary
+- Configurable category → staff/worker mapping
+- Nightly reconcile job (hooks + backfill are enough)
+- Implementation in this planning session (spec only)
+
+## Acceptance criteria
+
+- [x] Company list shows company name once (not ID + Company duplicate)
+- [x] List shows No of Staff, No of Workers, Total No of Employees
+- [x] Country is not a list column (still on form)
+- [x] Form shows the three fields read-only in a Headcount section
+- [x] Creating / updating / deleting active Company Links updates counts live
+- [x] Inactive links do not count
+- [x] Backfill sets correct counts for existing companies after migrate
+- [x] Unit tests above pass on the test site
+
+## Progress log
+
+| Date | Note |
+|------|------|
+| 2026-07-18 | Spec written after grilling; status `planned` |
+| 2026-07-18 | Implemented on `feat/company-list-employee-counts`: Company fields, recount helper, Company Link hooks (`after_delete` used instead of recount-in-`on_trash` so the deleted row is excluded), transfer SQL path recounts old company, backfill patch, unit tests (7) green |

--- a/specs/001-company-list-employee-counts.md
+++ b/specs/001-company-list-employee-counts.md
@@ -38,8 +38,9 @@ Place them in a read-only **Headcount** section on the Company **Details** tab (
 
 - Show: primary company title + the three count columns
 - **Remove** `in_list_view` from `country` (still on form)
-- **Remove** `in_list_view` from the `company` Data field (avoids double name)
-- Set `title_field` to `company` so the list/title uses the company name once
+- **Remove** `in_list_view` from the `company` Data field (avoids a second Company field column)
+- Set `title_field` to `company` so the subject column uses the company name
+- Set `frappe.listview_settings["Company"].hide_name_column = true` in `company_list.js` — required because with `title_field` set, Frappe still appends an **ID** column, and for `autoname: field:company` that ID equals the title (double name)
 
 ### Count rules
 

--- a/specs/001-company-list-employee-counts.md
+++ b/specs/001-company-list-employee-counts.md
@@ -32,7 +32,7 @@ Add three **Int** fields, read-only:
 | `no_of_workers` | Worker | `in_list_view` |
 | `total_no_of_employees` | Total | `in_list_view` |
 
-Place them in a read-only **Headcount** section on the Company **Details** tab (near company / country).
+Place them on a read-only **Headcount** tab — last tab on the Company form (after Payroll & Statutory).
 
 ### List view layout
 
@@ -87,7 +87,7 @@ No Playwright for this spec.
 - [x] Company list shows company name once (not ID + Company duplicate)
 - [x] List shows Staff, Worker, Total
 - [x] Country is not a list column (still on form)
-- [x] Form shows the three fields read-only in a Headcount section
+- [x] Form shows the three fields read-only on a last **Headcount** tab
 - [x] Creating / updating / deleting active Company Links updates counts live
 - [x] Inactive links do not count
 - [x] Backfill sets correct counts for existing companies after migrate
@@ -100,3 +100,4 @@ No Playwright for this spec.
 | 2026-07-18 | Spec written after grilling; status `planned` |
 | 2026-07-18 | Implemented on `feat/company-list-employee-counts`: Company fields, recount helper, Company Link hooks (`after_delete` used instead of recount-in-`on_trash` so the deleted row is excluded), transfer SQL path recounts old company, backfill patch, unit tests (7) green |
 | 2026-07-18 | Fix double name: `title_field` + no `in_list_view` on `company` were not enough — Frappe still appends an ID column when title_field ≠ name; added `company_list.js` with `hide_name_column: true` |
+| 2026-07-18 | Moved Headcount to its own last form tab (`headcount_tab`) |

--- a/specs/001-company-list-employee-counts.md
+++ b/specs/001-company-list-employee-counts.md
@@ -14,9 +14,9 @@ Company list view should show headcount at a glance (staff, workers, total) with
 
 On the **Company** Desk list (and a small read-only section on the Company form), show three columns/fields:
 
-1. **No of Staff**
-2. **No of Workers**
-3. **Total No of Employees** (= Staff + Workers)
+1. **Staff**
+2. **Worker**
+3. **Total** (= Staff + Workers)
 
 Also fix the duplicate company name on the list (ID + Company field both showing the same value).
 
@@ -28,9 +28,9 @@ Add three **Int** fields, read-only:
 
 | Fieldname | Label | Notes |
 |-----------|-------|--------|
-| `no_of_staff` | No of Staff | `in_list_view` |
-| `no_of_workers` | No of Workers | `in_list_view` |
-| `total_no_of_employees` | Total No of Employees | `in_list_view` |
+| `no_of_staff` | Staff | `in_list_view` |
+| `no_of_workers` | Worker | `in_list_view` |
+| `total_no_of_employees` | Total | `in_list_view` |
 
 Place them in a read-only **Headcount** section on the Company **Details** tab (near company / country).
 
@@ -85,7 +85,7 @@ No Playwright for this spec.
 ## Acceptance criteria
 
 - [x] Company list shows company name once (not ID + Company duplicate)
-- [x] List shows No of Staff, No of Workers, Total No of Employees
+- [x] List shows Staff, Worker, Total
 - [x] Country is not a list column (still on form)
 - [x] Form shows the three fields read-only in a Headcount section
 - [x] Creating / updating / deleting active Company Links updates counts live

--- a/specs/PROGRESS.md
+++ b/specs/PROGRESS.md
@@ -1,0 +1,23 @@
+# Specs progress
+
+Single board for all specs in this folder. New specs get the next number (`002-…`, `003-…`). Update status here when work moves.
+
+| # | Spec | Status | Notes |
+|---|------|--------|-------|
+| 001 | [Company list employee counts](./001-company-list-employee-counts.md) | done | List + form headcount from Company Link; tests passing |
+
+## Status legend
+
+| Status | Meaning |
+|--------|---------|
+| `planned` | Spec written; not started |
+| `in progress` | Implementation underway on a `feat/` / `fix/` branch |
+| `done` | Merged / complete; keep the row for history |
+| `cancelled` | Won't do; leave a short note |
+
+## Conventions
+
+- One markdown file per spec: `specs/NNN-short-slug.md`
+- Numbers are zero-padded (`001`, `002`, …) so files sort naturally
+- Commit the spec before development commits (see `AGENTS.md`)
+- Reconcile this board after each meaningful phase


### PR DESCRIPTION
## Why?

Company list should show headcount at a glance without opening each company or running a report.

## What?

- Staff, Worker, and Total columns on Company list (from active Company Link)
- Read-only Headcount tab on Company form (last tab)
- Single company name in list (no ID duplicate)
- Spec `001` + progress board under `specs/`

## How?

Denormalized Int fields on Company, kept in sync via Company Link hooks + migrate backfill. Unit tests cover recount behaviour.


Made with [Cursor](https://cursor.com)