### PR TITLE
fix: auto-Absent for joining/left disabled days

### DIFF
--- a/saral_hr/saral_hr/page/mark_attendance/mark_attendance.js
+++ b/saral_hr/saral_hr/page/mark_attendance/mark_attendance.js
@@ -1834,10 +1834,11 @@ function init_mark_attendance($main) {
     // ════════════════════════════════════════════════════════════════════════
     function resolveInitialRec(rawStatus, isHoliday, isDefaultWeeklyOff, isOutsideTenure) {
         if (!rawStatus) {
-            if (!isOutsideTenure) {
-                if (isHoliday)          return { mode: "full", status: "Holiday"    };
-                if (isDefaultWeeklyOff) return { mode: "full", status: "Weekly Off" };
-            }
+            // Outside joining/left window: keep row disabled, but treat as Absent
+            // so salary does not see blank unmarked days.
+            if (isOutsideTenure) return { mode: "full", status: "Absent" };
+            if (isHoliday)          return { mode: "full", status: "Holiday"    };
+            if (isDefaultWeeklyOff) return { mode: "full", status: "Weekly Off" };
             return { mode: "full", status: "" };
         }
         if (typeof rawStatus === "object" && rawStatus.mode === "half") return rawStatus;
@@ -1865,55 +1866,66 @@ function init_mark_attendance($main) {
                 holidayDates = {};
                 (holidayRes.message || []).forEach(function (h) { holidayDates[h] = true; });
 
+                function loadAttendanceAndRender() {
+                    frappe.call({
+                        method: "saral_hr.saral_hr.page.mark_attendance.mark_attendance.get_attendance_between_dates",
+                        args: { employee: employee, start_date: startDate, end_date: endDate },
+                        callback: function (res) {
+                            var attendanceMap = res.message || {};
+                            attendanceTableData = {}; originalAttendanceData = {};
+                            dirtyDates.clear(); tbody.innerHTML = "";
+
+                            var current = new Date(startDate);
+                            var end     = new Date(endDate);
+                            var today   = new Date(); today.setHours(0, 0, 0, 0);
+                            var rowIdx  = 0;
+
+                            while (current <= end) {
+                                var cd = new Date(current); cd.setHours(0, 0, 0, 0);
+                                var dayName = cd.toLocaleDateString("en-US", { weekday: "long" });
+                                var dateKey = cd.getFullYear() + "-" +
+                                    String(cd.getMonth() + 1).padStart(2, "0") + "-" +
+                                    String(cd.getDate()).padStart(2, "0");
+
+                                var isDefaultWeeklyOff = weeklyOffDays.includes(dayName.toLowerCase());
+                                var isHoliday          = holidayDates[dateKey] === true;
+                                var isFuture           = cd > today;
+                                var isBeforeJoining    = joiningDate ? (cd < joiningDate) : false;
+                                var isAfterLeft        = leftDate    ? (cd > leftDate)    : false;
+                                var isOutsideTenure    = isBeforeJoining || isAfterLeft;
+
+                                var raw      = attendanceMap[dateKey];
+                                var savedRec = resolveInitialRec(raw, isHoliday, isDefaultWeeklyOff, isOutsideTenure);
+
+                                attendanceTableData[dateKey] = savedRec;
+                                if (raw) originalAttendanceData[dateKey] = JSON.parse(JSON.stringify(savedRec));
+
+                                tbody.appendChild(buildRow(
+                                    dateKey, dayName, cd, savedRec,
+                                    isHoliday, isDefaultWeeklyOff,
+                                    isFuture, isOutsideTenure, rowIdx++
+                                ));
+                                current.setDate(current.getDate() + 1);
+                            }
+
+                            applySubtypeColumnsToBdy();
+                            applyAllocationColumnGating();
+                            hideTableLoading();
+                            updateCounts();
+                            updateScrollHeight();
+                            applyTableLockClass();
+                        },
+                        error: function () { hideTableLoading(); }
+                    });
+                }
+
+                // Persist Absent for past outside-tenure days before rendering
+                // so salary sees recorded attendance (rows stay non-editable).
                 frappe.call({
-                    method: "saral_hr.saral_hr.page.mark_attendance.mark_attendance.get_attendance_between_dates",
+                    method: "saral_hr.saral_hr.page.mark_attendance.mark_attendance.ensure_outside_tenure_absent",
                     args: { employee: employee, start_date: startDate, end_date: endDate },
-                    callback: function (res) {
-                        var attendanceMap = res.message || {};
-                        attendanceTableData = {}; originalAttendanceData = {};
-                        dirtyDates.clear(); tbody.innerHTML = "";
-
-                        var current = new Date(startDate);
-                        var end     = new Date(endDate);
-                        var today   = new Date(); today.setHours(0, 0, 0, 0);
-                        var rowIdx  = 0;
-
-                        while (current <= end) {
-                            var cd = new Date(current); cd.setHours(0, 0, 0, 0);
-                            var dayName = cd.toLocaleDateString("en-US", { weekday: "long" });
-                            var dateKey = cd.getFullYear() + "-" +
-                                String(cd.getMonth() + 1).padStart(2, "0") + "-" +
-                                String(cd.getDate()).padStart(2, "0");
-
-                            var isDefaultWeeklyOff = weeklyOffDays.includes(dayName.toLowerCase());
-                            var isHoliday          = holidayDates[dateKey] === true;
-                            var isFuture           = cd > today;
-                            var isBeforeJoining    = joiningDate ? (cd < joiningDate) : false;
-                            var isAfterLeft        = leftDate    ? (cd > leftDate)    : false;
-                            var isOutsideTenure    = isBeforeJoining || isAfterLeft;
-
-                            var raw      = attendanceMap[dateKey];
-                            var savedRec = resolveInitialRec(raw, isHoliday, isDefaultWeeklyOff, isOutsideTenure);
-
-                            attendanceTableData[dateKey] = savedRec;
-                            if (raw) originalAttendanceData[dateKey] = JSON.parse(JSON.stringify(savedRec));
-
-                            tbody.appendChild(buildRow(
-                                dateKey, dayName, cd, savedRec,
-                                isHoliday, isDefaultWeeklyOff,
-                                isFuture, isOutsideTenure, rowIdx++
-                            ));
-                            current.setDate(current.getDate() + 1);
-                        }
-
-                        applySubtypeColumnsToBdy();
-                        applyAllocationColumnGating();
-                        hideTableLoading();
-                        updateCounts();
-                        updateScrollHeight();
-                        applyTableLockClass();
-                    },
-                    error: function () { hideTableLoading(); }
+                    callback: function () { loadAttendanceAndRender(); },
+                    error: function () { loadAttendanceAndRender(); }
                 });
             },
             error: function () { hideTableLoading(); }

--- a/saral_hr/saral_hr/page/mark_attendance/mark_attendance.py
+++ b/saral_hr/saral_hr/page/mark_attendance/mark_attendance.py
@@ -679,3 +679,98 @@ def get_employee_joining_date(employee):
         "joining_date": str(result.date_of_joining) if result.date_of_joining else None,
         "left_date":    str(result.left_date)        if result.left_date        else None,
     }
+
+
+# ---------------------------------------------------------------------------
+# Outside-tenure Absent (pre-joining / post-left)
+# ---------------------------------------------------------------------------
+
+@frappe.whitelist()
+def ensure_outside_tenure_absent(employee, start_date, end_date):
+    """
+    Persist Absent for past days before date_of_joining or after left_date.
+
+    Mark Attendance keeps those rows non-editable; without a stored status the
+    month has blank days. Recording Absent fills them while still blocking edits.
+    """
+    import datetime
+    from frappe.utils import get_first_day, today
+
+    permitted = _get_permitted_employees()
+    if permitted is not None and employee not in permitted:
+        return {"created": 0}
+
+    if not employee or not start_date or not end_date:
+        return {"created": 0}
+
+    cl = frappe.db.get_value(
+        "Company Link",
+        employee,
+        ["date_of_joining", "left_date"],
+        as_dict=True,
+    )
+    if not cl:
+        return {"created": 0}
+
+    joining = getdate(cl.date_of_joining) if cl.date_of_joining else None
+    left = getdate(cl.left_date) if cl.left_date else None
+    if not joining and not left:
+        return {"created": 0}
+
+    start = getdate(start_date)
+    end = getdate(end_date)
+    today_date = getdate(today())
+    created = 0
+
+    current = start
+    while current <= end:
+        if current > today_date:
+            current += datetime.timedelta(days=1)
+            continue
+
+        outside = (joining and current < joining) or (left and current > left)
+        if not outside:
+            current += datetime.timedelta(days=1)
+            continue
+
+        month_start = str(get_first_day(current))
+        if frappe.db.exists(
+            "Salary Slip",
+            {"employee": employee, "start_date": month_start, "docstatus": 1},
+        ):
+            current += datetime.timedelta(days=1)
+            continue
+
+        existing = frappe.db.get_value(
+            "Attendance",
+            {
+                "employee": employee,
+                "attendance_date": current,
+                "docstatus": ["<", 2],
+            },
+            "name",
+        )
+        if existing:
+            current += datetime.timedelta(days=1)
+            continue
+
+        doc = frappe.get_doc(
+            {
+                "doctype": "Attendance",
+                "employee": employee,
+                "attendance_date": current,
+                "status": "Absent",
+                "custom_first_half": "",
+                "custom_second_half": "",
+            }
+        )
+        doc.flags.ignore_validate = True
+        doc.flags.ignore_mandatory = True
+        doc.insert(ignore_permissions=True)
+        created += 1
+        current += datetime.timedelta(days=1)
+
+    if created:
+        frappe.db.commit()
+
+    return {"created": created}

--- a/saral_hr/tests/test_mark_attendance_outside_tenure.py
+++ b/saral_hr/tests/test_mark_attendance_outside_tenure.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, sj and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, get_first_day, get_last_day, getdate
+
+from saral_hr.saral_hr.page.mark_attendance.mark_attendance import (
+	ensure_outside_tenure_absent,
+)
+
+
+def _uid() -> str:
+	return frappe.generate_hash(length=6)
+
+
+def _make_company() -> str:
+	uid = _uid()
+	doc = frappe.get_doc(
+		{
+			"doctype": "Company",
+			"company": f"_Test MA Tenure {uid}",
+			"abbr": f"T{uid}"[:8],
+			"country": "India",
+			"default_currency": "INR",
+			"salary_calculation_based_on": "Exclude Weekly Offs (Working Days)",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_employee() -> str:
+	doc = frappe.get_doc(
+		{
+			"doctype": "Employee",
+			"naming_series": "HR-EMP-",
+			"first_name": f"TenureEmp{_uid()}",
+			"gender": "Other",
+			"date_of_birth": "1990-01-01",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _ensure_category(name: str = "Staff"):
+	if frappe.db.exists("Category", name):
+		return name
+	doc = frappe.get_doc({"doctype": "Category", "category": name, "has_subtype": 0})
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_company_link(employee: str, company: str, joining, left=None):
+	doc = frappe.get_doc(
+		{
+			"doctype": "Company Link",
+			"employee": employee,
+			"company": company,
+			"category": _ensure_category(),
+			"date_of_joining": getdate(joining),
+			"left_date": getdate(left) if left else None,
+			"is_active": 1,
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+class TestMarkAttendanceOutsideTenure(FrappeTestCase):
+	def test_ensure_marks_pre_joining_days_absent(self):
+		company = _make_company()
+		employee = _make_employee()
+		# Mid-month join: days before joining should become Absent
+		joining = getdate("2024-06-10")
+		cl = _make_company_link(employee, company, joining)
+		start = get_first_day(joining)
+		end = get_last_day(joining)
+
+		result = ensure_outside_tenure_absent(cl, str(start), str(end))
+		self.assertGreater(result["created"], 0)
+
+		pre_join = frappe.db.get_all(
+			"Attendance",
+			filters={
+				"employee": cl,
+				"attendance_date": ["between", [str(start), str(add_days(joining, -1))]],
+				"docstatus": ["<", 2],
+			},
+			fields=["attendance_date", "status"],
+		)
+		self.assertTrue(pre_join)
+		self.assertTrue(all(r.status == "Absent" for r in pre_join))
+
+		# Joining day itself must not be auto-marked
+		self.assertFalse(
+			frappe.db.exists(
+				"Attendance",
+				{"employee": cl, "attendance_date": joining, "docstatus": ["<", 2]},
+			)
+		)
+
+	def test_ensure_is_idempotent_and_skips_existing(self):
+		company = _make_company()
+		employee = _make_employee()
+		joining = getdate("2024-03-05")
+		cl = _make_company_link(employee, company, joining)
+		start = get_first_day(joining)
+		end = get_last_day(joining)
+
+		first = ensure_outside_tenure_absent(cl, str(start), str(end))
+		second = ensure_outside_tenure_absent(cl, str(start), str(end))
+		self.assertGreater(first["created"], 0)
+		self.assertEqual(second["created"], 0)
+
+	def test_ensure_marks_days_after_left_date(self):
+		company = _make_company()
+		employee = _make_employee()
+		joining = getdate("2024-01-01")
+		left = getdate("2024-04-10")
+		cl = _make_company_link(employee, company, joining, left=left)
+		start = get_first_day(left)
+		end = get_last_day(left)
+
+		result = ensure_outside_tenure_absent(cl, str(start), str(end))
+		self.assertGreater(result["created"], 0)
+
+		after_left = frappe.db.get_all(
+			"Attendance",
+			filters={
+				"employee": cl,
+				"attendance_date": ["between", [str(add_days(left, 1)), str(end)]],
+				"docstatus": ["<", 2],
+			},
+			fields=["status"],
+		)
+		self.assertTrue(after_left)
+		self.assertTrue(all(r.status == "Absent" for r in after_left))


### PR DESCRIPTION
## Problem
On Mark Attendance, days before date of joining or after left date are disabled and left blank. That leaves unmarked days in the month and skews attendance/salary day counts.

## Solution
- Keep those rows disabled (no user edit)
- Auto-create **Absent** attendance for past outside-tenure days when the month table loads
- Show Absent in the UI for those rows

## Test plan
- [x] Unit tests for pre-joining and post-left Absent creation (incl. idempotency)
- [x] Temp-revert of insert path → tests fail; restore → tests pass
- [x] UI: mid-month join employee — pre-join days are disabled + Absent; joining day remains editable/unmarked

Made with [Cursor](https://cursor.com)