### PR TITLE
feat: Company salary amount rounding digits

### DIFF
--- a/saral_hr/saral_hr/doctype/company/company.json
+++ b/saral_hr/saral_hr/doctype/company/company.json
@@ -51,7 +51,9 @@
   "no_of_staff",
   "no_of_workers",
   "column_break_headcount",
-  "total_no_of_employees"
+  "total_no_of_employees",
+  "misc_settings_tab",
+  "salary_amount_rounding_digits"
  ],
  "fields": [
   {
@@ -297,11 +299,25 @@
    "label": "Total",
    "non_negative": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "misc_settings_tab",
+   "fieldtype": "Tab Break",
+   "label": "Misc Settings"
+  },
+  {
+   "default": "2",
+   "description": "Decimal places for salary component amounts. 0 = round to whole rupees (no paise). 2 = keep paise.",
+   "fieldname": "salary_amount_rounding_digits",
+   "fieldtype": "Select",
+   "label": "Salary Amount Rounding Digits",
+   "options": "0\n2",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-18 07:00:00.000000",
+ "modified": "2026-08-02 08:00:00.000000",
  "modified_by": "Administrator",
  "module": "Saral Hr",
  "name": "Company",

--- a/saral_hr/saral_hr/doctype/salary_slip/salary_slip.js
+++ b/saral_hr/saral_hr/doctype/salary_slip/salary_slip.js
@@ -6,6 +6,17 @@ frappe.ui.form.on("Salary Slip", {
     refresh(frm) {
         if (!frm.doc.currency) frm.set_value("currency", "INR");
         frm.set_query("employee", () => ({ filters: { is_active: 1 } }));
+        if (frm.doc.company && frm._salary_rounding_digits === undefined) {
+            frappe.db.get_value(
+                "Company",
+                frm.doc.company,
+                "salary_amount_rounding_digits",
+                (comp) => {
+                    frm._salary_rounding_digits =
+                        parseInt(comp && comp.salary_amount_rounding_digits, 10) === 0 ? 0 : 2;
+                }
+            );
+        }
     },
 
     employee(frm) {
@@ -13,12 +24,20 @@ frappe.ui.form.on("Salary Slip", {
         reset_form(frm);
         frappe.db.get_value("Company Link", frm.doc.employee, "company", (r) => {
             if (r && r.company) {
-                frappe.db.get_value("Company", r.company, "salary_calculation_based_on", (comp) => {
-                    if (comp && comp.salary_calculation_based_on)
-                        frm.set_value("working_days_calculation_method", comp.salary_calculation_based_on);
-                    if (frm.doc.start_date) check_duplicate_and_fetch(frm);
-                });
+                frappe.db.get_value(
+                    "Company",
+                    r.company,
+                    ["salary_calculation_based_on", "salary_amount_rounding_digits"],
+                    (comp) => {
+                        if (comp && comp.salary_calculation_based_on)
+                            frm.set_value("working_days_calculation_method", comp.salary_calculation_based_on);
+                        frm._salary_rounding_digits =
+                            parseInt(comp && comp.salary_amount_rounding_digits, 10) === 0 ? 0 : 2;
+                        if (frm.doc.start_date) check_duplicate_and_fetch(frm);
+                    }
+                );
             } else {
+                frm._salary_rounding_digits = 2;
                 if (frm.doc.start_date) check_duplicate_and_fetch(frm);
             }
         });
@@ -100,6 +119,14 @@ function is_pt(comp_name) {
 
 function round_net_salary(value) {
     return Math.floor(value + 0.5);
+}
+
+function salary_amount_digits(frm) {
+    return frm && frm._salary_rounding_digits === 0 ? 0 : 2;
+}
+
+function round_salary_amount(frm, value) {
+    return flt(value, salary_amount_digits(frm));
 }
 
 // ─── Duplicate check + full fetch ─────────────────────────────────────────────
@@ -403,7 +430,7 @@ function recalculate_salary(frm, wd_override, pd_override, phd_override) {
             amount = base;
         }
 
-        row.amount = flt(amount, 2);
+        row.amount = round_salary_amount(frm, amount);
         total_earnings += row.amount;
 
         if (comp.includes("basic")) basic_amount = row.amount;
@@ -438,7 +465,7 @@ function recalculate_salary(frm, wd_override, pd_override, phd_override) {
             amount = base;
         }
 
-        row.amount = flt(amount, 2);
+        row.amount = round_salary_amount(frm, amount);
         total_deductions += row.amount;
 
         if ((row.salary_component || "").toLowerCase().includes("retention")) retention += row.amount;
@@ -462,20 +489,21 @@ function recalculate_salary(frm, wd_override, pd_override, phd_override) {
             amount = base;
         }
 
-        row.amount = flt(amount, 2);
+        row.amount = round_salary_amount(frm, amount);
         total_employer_contribution += row.amount;
     });
 
     const raw_net = total_earnings - total_deductions;
     const net = round_net_salary(raw_net);
+    const digits = salary_amount_digits(frm);
 
     frm.set_value({
-        total_earnings: flt(total_earnings, 2),
-        total_deductions: flt(total_deductions, 2),
+        total_earnings: flt(total_earnings, digits),
+        total_deductions: flt(total_deductions, digits),
         net_salary: net,
-        total_basic_da: flt(basic_amount + da_amount, 2),
-        total_employer_contribution: flt(total_employer_contribution, 2),
-        retention: flt(retention, 2)
+        total_basic_da: flt(basic_amount + da_amount, digits),
+        total_employer_contribution: flt(total_employer_contribution, digits),
+        retention: flt(retention, digits)
     });
 
     frm.refresh_fields(["earnings", "deductions", "employer_share"]);

--- a/saral_hr/saral_hr/doctype/salary_slip/salary_slip.py
+++ b/saral_hr/saral_hr/doctype/salary_slip/salary_slip.py
@@ -17,6 +17,31 @@ def _round_net_salary(value):
     return int(Decimal(str(flt(value, 2))).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
 
 
+def get_salary_amount_rounding_digits(company=None):
+    """Company Misc Setting: 0 = whole rupees, 2 = paise. Default 2."""
+    digits = 2
+    if company:
+        raw = frappe.db.get_value("Company", company, "salary_amount_rounding_digits")
+        if raw is not None and raw != "":
+            try:
+                digits = int(raw)
+            except (TypeError, ValueError):
+                digits = 2
+    return 0 if digits == 0 else 2
+
+
+def _company_for_employee(employee):
+    if not employee:
+        return None
+    return frappe.db.get_value("Company Link", employee, "company")
+
+
+def round_salary_amount(value, company=None, digits=None):
+    if digits is None:
+        digits = get_salary_amount_rounding_digits(company)
+    return flt(value, digits)
+
+
 class SalarySlip(Document):
     def validate(self):
         if self.start_date:
@@ -212,6 +237,7 @@ def get_salary_structure_for_employee(
     phd    = flt(physical_working_days)   if physical_working_days   is not None else None
     vp_pct = flt(variable_pay_percentage) / 100.0 if variable_pay_percentage is not None else None
     has_att_data = (wd is not None and pd is not None and phd is not None and vp_pct is not None)
+    amount_digits = get_salary_amount_rounding_digits(ssa_doc.company)
 
     def _comp_meta(comp_name):
         return frappe.db.get_value(
@@ -259,12 +285,12 @@ def get_salary_structure_for_employee(
         else:
             actual = _prorate(base, dep_pd, dep_phd, is_daily_wage, per_day_rate, row.salary_component)
 
-        actual_earnings_map[row.salary_component] = flt(actual, 2)
+        actual_earnings_map[row.salary_component] = flt(actual, amount_digits)
         earnings.append({
             "salary_component":                 row.salary_component,
             "abbr":                             meta.get("salary_component_abbr") or getattr(row, "abbr", "") or "",
-            "amount":                           base,
-            "base_amount":                      base,
+            "amount":                           flt(base, amount_digits),
+            "base_amount":                      flt(base, amount_digits),
             "per_day_rate":                     per_day_rate,
             "daily_wage_component":             is_daily_wage,
             "depends_on_payment_days":          dep_pd,
@@ -296,7 +322,7 @@ def get_salary_structure_for_employee(
         meta          = _comp_meta(row.salary_component)
         is_daily_wage = int(meta.get("daily_wage_component") or getattr(row, "daily_wage_component", 0) or 0)
         per_day_rate  = flt(getattr(row, "per_day_rate", None) or 0)
-        amount        = flt(row.amount, 2)
+        amount        = flt(row.amount, amount_digits)
         if _is_pt_component(row.salary_component):
             amount = 300.0 if current_month == "February" else 200.0
         deductions.append({
@@ -320,8 +346,8 @@ def get_salary_structure_for_employee(
         employer_share.append({
             "salary_component":                 row.salary_component,
             "abbr":                             meta.get("salary_component_abbr") or getattr(row, "abbr", "") or "",
-            "amount":                           flt(row.amount, 2),
-            "base_amount":                      flt(row.amount, 2),
+            "amount":                           flt(row.amount, amount_digits),
+            "base_amount":                      flt(row.amount, amount_digits),
             "per_day_rate":                     per_day_rate,
             "daily_wage_component":             is_daily_wage,
             "employer_contribution":            1,
@@ -348,7 +374,7 @@ def get_salary_structure_for_employee(
         for d in (recomputed.get("deductions") or []):
             if _is_pt_component(d["salary_component"]) and _is_pt_exempt(employee, start_date):
                 continue
-            amount = flt(d["amount"], 2)
+            amount = flt(d["amount"], amount_digits)
             if _is_pt_component(d["salary_component"]):
                 amount = 300.0 if current_month == "February" else 200.0
             deductions.append({
@@ -361,7 +387,7 @@ def get_salary_structure_for_employee(
         for d in (recomputed.get("employer_share") or []):
             employer_share.append({
                 "salary_component": d["salary_component"], "abbr": d.get("abbr") or "",
-                "amount": flt(d["amount"], 2), "base_amount": flt(d["amount"], 2),
+                "amount": flt(d["amount"], amount_digits), "base_amount": flt(d["amount"], amount_digits),
                 "per_day_rate": 0, "daily_wage_component": 0, "employer_contribution": 1,
                 "depends_on_payment_days": 0, "depends_on_physical_working_days": 0,
             })
@@ -422,6 +448,11 @@ def calculate_salary_slip_amounts_exact(
     pd           = flt(salary_slip.payment_days)
     phd          = flt(salary_slip.physical_working_days)
     variable_pct = flt(variable_pay_percentage)
+    company = (
+        getattr(salary_slip, "company", None)
+        or _company_for_employee(getattr(salary_slip, "employee", None))
+    )
+    digits = get_salary_amount_rounding_digits(company)
 
     total_earnings = total_deductions = total_employer_contribution = 0.0
     basic_amount = da_amount = retention = 0.0
@@ -451,7 +482,7 @@ def calculate_salary_slip_amounts_exact(
         else:
             amount = base
 
-        row.amount      = flt(amount, 2)
+        row.amount      = flt(amount, digits)
         total_earnings += row.amount
         if "basic" in comp:
             basic_amount = row.amount
@@ -482,7 +513,7 @@ def calculate_salary_slip_amounts_exact(
         else:
             amount = base
 
-        row.amount        = flt(amount, 2)
+        row.amount        = flt(amount, digits)
         total_deductions += row.amount
         if "retention" in (row.salary_component or "").lower():
             retention += row.amount
@@ -495,19 +526,20 @@ def calculate_salary_slip_amounts_exact(
 
         if is_daily_wage and per_day_rate > 0:
             row.amount = flt(
-                per_day_rate * phd if row.depends_on_physical_working_days else per_day_rate * pd, 2
+                per_day_rate * phd if row.depends_on_physical_working_days else per_day_rate * pd,
+                digits,
             )
         else:
-            row.amount = flt(base, 2)
+            row.amount = flt(base, digits)
 
         total_employer_contribution += row.amount
 
-    salary_slip.total_earnings              = flt(total_earnings, 2)
-    salary_slip.total_deductions            = flt(total_deductions, 2)
+    salary_slip.total_earnings              = flt(total_earnings, digits)
+    salary_slip.total_deductions            = flt(total_deductions, digits)
     salary_slip.net_salary                  = _round_net_salary(total_earnings - total_deductions)
-    salary_slip.total_basic_da              = flt(basic_amount + da_amount, 2)
-    salary_slip.total_employer_contribution = flt(total_employer_contribution, 2)
-    salary_slip.retention                   = flt(retention, 2)
+    salary_slip.total_basic_da              = flt(basic_amount + da_amount, digits)
+    salary_slip.total_employer_contribution = flt(total_employer_contribution, digits)
+    salary_slip.retention                   = flt(retention, digits)
 
 
 def _is_da_component(comp_name, abbr):
@@ -1337,6 +1369,7 @@ def bulk_generate_salary_slips(employees, year, month):
             ss = frappe.new_doc("Salary Slip")
             ss.employee = employee; ss.start_date = start_date
             ss.end_date = get_last_day(getdate(start_date)); ss.currency = "INR"
+            ss.company = company_name
             ss.salary_structure = sd.get('salary_structure'); ss.working_days_calculation_method = wdcm
 
             ss.month_days              = att.get('total_days', 0)

--- a/saral_hr/saral_hr/doctype/salary_slip/test_salary_slip.py
+++ b/saral_hr/saral_hr/doctype/salary_slip/test_salary_slip.py
@@ -5,7 +5,12 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, get_first_day, get_last_day, getdate
 
-from saral_hr.saral_hr.doctype.salary_slip.salary_slip import get_attendance_and_days
+from saral_hr.saral_hr.doctype.salary_slip.salary_slip import (
+	calculate_salary_slip_amounts_exact,
+	get_attendance_and_days,
+	get_salary_amount_rounding_digits,
+	round_salary_amount,
+)
 
 
 def _uid() -> str:
@@ -111,3 +116,51 @@ class TestSalarySlipWorkingDays(FrappeTestCase):
 		self.assertEqual(att["present_days"], float(post_join_days))
 		self.assertEqual(att["absent_days"], float(month_days - post_join_days))
 		self.assertEqual(att["payment_days"], float(post_join_days))
+
+
+class TestSalaryAmountRounding(FrappeTestCase):
+	def test_rounding_digits_helper(self):
+		company = _make_company()
+		frappe.db.set_value("Company", company, "salary_amount_rounding_digits", "0")
+		self.assertEqual(get_salary_amount_rounding_digits(company), 0)
+		self.assertEqual(round_salary_amount(10.6, company), 11.0)
+		self.assertEqual(round_salary_amount(10.4, company), 10.0)
+
+		frappe.db.set_value("Company", company, "salary_amount_rounding_digits", "2")
+		self.assertEqual(get_salary_amount_rounding_digits(company), 2)
+		self.assertEqual(round_salary_amount(10.456, company), 10.46)
+
+		self.assertEqual(get_salary_amount_rounding_digits(None), 2)
+
+	def test_calculate_uses_company_rounding_digits(self):
+		company = _make_company()
+		frappe.db.set_value("Company", company, "salary_amount_rounding_digits", "0")
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-01-01", weekly_off="")
+
+		ss = frappe.new_doc("Salary Slip")
+		ss.employee = cl
+		ss.company = company
+		ss.start_date = "2024-01-01"
+		ss.end_date = "2024-01-31"
+		ss.total_working_days = 30
+		ss.payment_days = 15
+		ss.physical_working_days = 15
+		row = ss.append("earnings", {})
+		row.salary_component = "Basic"
+		row.abbr = "BASIC"
+		row.base_amount = 10000
+		row.amount = 10000
+		row.depends_on_payment_days = 1
+		row.depends_on_physical_working_days = 0
+
+		calculate_salary_slip_amounts_exact(ss, 0, "2024-01-01")
+		# 10000 * 15/30 = 5000 exactly; use a non-integer case via payment_days
+		ss.payment_days = 10
+		calculate_salary_slip_amounts_exact(ss, 0, "2024-01-01")
+		# 10000 * 10/30 = 3333.333... → rounds to 3333 with digits=0
+		self.assertEqual(ss.earnings[0].amount, 3333.0)
+
+		frappe.db.set_value("Company", company, "salary_amount_rounding_digits", "2")
+		calculate_salary_slip_amounts_exact(ss, 0, "2024-01-01")
+		self.assertEqual(ss.earnings[0].amount, 3333.33)


### PR DESCRIPTION
## Why?
Salary component amounts were always rounded to 2 decimals. Some companies need whole-rupee rounding (no paise).

## What?
- New Company tab **Misc Settings** with **Salary Amount Rounding Digits** (`0` or `2`, default `2`)
- Salary slip computation (server + Desk form) uses that setting

## How?
- `0` → `flt(amount, 0)` (normal round, no paise)
- `2` → `flt(amount, 2)` (paise)

## Test plan
- [x] Unit tests for digits helper and calculate path (0 → 3333, 2 → 3333.33)
- [x] migrate applied locally
- [ ] Set Company → Misc Settings → 0, regenerate a slip, confirm no paise on components

Made with [Cursor](https://cursor.com)