### PR TITLE
feat: Maharashtra professional tax slabs on Company

### DIFF
--- a/saral_hr/patches.txt
+++ b/saral_hr/patches.txt
@@ -8,3 +8,4 @@ saral_hr.patches.set_pdf_options
 saral_hr.patches.backfill_company_employee_counts
 saral_hr.patches.seed_maharashtra_pt_periods
 saral_hr.patches.clear_pt_special_component
+saral_hr.patches.migrate_pt_february_to_slabs

--- a/saral_hr/patches.txt
+++ b/saral_hr/patches.txt
@@ -6,3 +6,5 @@
 # Patches added in this section will be executed after doctypes are migrated
 saral_hr.patches.set_pdf_options
 saral_hr.patches.backfill_company_employee_counts
+saral_hr.patches.seed_maharashtra_pt_periods
+saral_hr.patches.clear_pt_special_component

--- a/saral_hr/patches/clear_pt_special_component.py
+++ b/saral_hr/patches/clear_pt_special_component.py
@@ -1,0 +1,21 @@
+import frappe
+
+
+def execute():
+	"""PT is calculated from Company slabs — clear special monthly amounts."""
+	if not frappe.db.exists("Salary Component", "Professional Tax"):
+		return
+
+	doc = frappe.get_doc("Salary Component", "Professional Tax")
+	changed = False
+	if int(getattr(doc, "is_special_component", 0) or 0):
+		doc.is_special_component = 0
+		changed = True
+	if doc.get("monthly_amounts"):
+		doc.set("monthly_amounts", [])
+		changed = True
+	if hasattr(doc, "is_pt_component") and not int(doc.is_pt_component or 0):
+		doc.is_pt_component = 1
+		changed = True
+	if changed:
+		doc.save(ignore_permissions=True)

--- a/saral_hr/patches/migrate_pt_february_to_slabs.py
+++ b/saral_hr/patches/migrate_pt_february_to_slabs.py
@@ -1,0 +1,64 @@
+import json
+
+import frappe
+from frappe.utils import flt
+
+
+# Male tax → February amount (Maharashtra standard)
+_MALE_TAX_TO_FEB = {
+	175.0: 275.0,
+	200.0: 300.0,
+}
+
+
+def execute():
+	"""Move February override onto slabs; drop obsolete period february_amount column."""
+	if not frappe.db.table_exists("Professional Tax Period"):
+		return
+
+	rows = frappe.db.sql(
+		"""
+		SELECT name, slabs
+		FROM `tabProfessional Tax Period`
+		""",
+		as_dict=True,
+	)
+
+	for row in rows:
+		slabs = []
+		try:
+			parsed = json.loads(row.slabs or "[]")
+			if isinstance(parsed, list):
+				slabs = parsed
+		except (json.JSONDecodeError, TypeError, ValueError):
+			slabs = []
+
+		changed = False
+		for slab in slabs:
+			if "february_amount" not in slab:
+				slab["february_amount"] = None
+				changed = True
+			if slab.get("gender") != "Male":
+				continue
+			if slab.get("february_amount") not in (None, ""):
+				continue
+			tax = flt(slab.get("tax_amount"))
+			feb = _MALE_TAX_TO_FEB.get(tax)
+			if feb is None:
+				continue
+			slab["february_amount"] = feb
+			changed = True
+
+		if changed:
+			frappe.db.set_value(
+				"Professional Tax Period",
+				row.name,
+				"slabs",
+				json.dumps(slabs),
+				update_modified=False,
+			)
+
+	if frappe.db.has_column("Professional Tax Period", "february_amount"):
+		frappe.db.sql_ddl(
+			"ALTER TABLE `tabProfessional Tax Period` DROP COLUMN `february_amount`"
+		)

--- a/saral_hr/patches/seed_maharashtra_pt_periods.py
+++ b/saral_hr/patches/seed_maharashtra_pt_periods.py
@@ -1,0 +1,11 @@
+import frappe
+
+from saral_hr.saral_hr.doctype.company.company import seed_pt_period_on_company
+
+
+def execute():
+	"""Seed Maharashtra PT period on companies that have none."""
+	if not frappe.db.table_exists("Professional Tax Period"):
+		return
+	for name in frappe.get_all("Company", pluck="name"):
+		seed_pt_period_on_company(name)

--- a/saral_hr/saral_hr/doctype/company/company.js
+++ b/saral_hr/saral_hr/doctype/company/company.js
@@ -25,7 +25,15 @@ $(document).on("page-change", function () {
         '[data-fieldname="pf_dependent_component"] .form-grid-container,',
         '[data-fieldname="pf_dependent_component"] .frappe-control,',
         '[data-fieldname="pf_dependent_component"] .grid-body,',
-        '[data-fieldname="pf_dependent_component"] .no-data-message',
+        '[data-fieldname="pf_dependent_component"] .no-data-message,',
+        '[data-fieldname="pt_periods"] .grid-row,',
+        '[data-fieldname="pt_periods"] .grid-heading-row,',
+        '[data-fieldname="pt_periods"] .grid-footer,',
+        '[data-fieldname="pt_periods"] .grid-add-row,',
+        '[data-fieldname="pt_periods"] .form-grid-container,',
+        '[data-fieldname="pt_periods"] .frappe-control,',
+        '[data-fieldname="pt_periods"] .grid-body,',
+        '[data-fieldname="pt_periods"] .no-data-message',
         '{ display: none !important; }'
     ].join(" ");
     $("head").append('<style id="esic-pf-grid-hide-style">' + css + '</style>');
@@ -35,6 +43,7 @@ frappe.ui.form.on("Company", {
     refresh(frm) {
         render_esic_period_ui(frm);
         render_pf_period_ui(frm);
+        render_pt_period_ui(frm);
         render_salary_calc_description(frm);
         render_salary_calc_preview(frm);
     },
@@ -477,6 +486,355 @@ function _reset_form($ui) {
         $ui.find(".period-from-date, .period-to-date").val("");
         $ui.find(".checkbox-list input").prop("checked", false);
         $ui.find(".rate-field").val("");
+    });
+}
+
+// ─────────────────────────────────────────────────────────────
+//  Professional Tax UI
+// ─────────────────────────────────────────────────────────────
+
+const MAHARASHTRA_PT_SLABS = [
+    { gender: "Male", from_amount: 0, to_amount: 7500, tax_amount: 0 },
+    { gender: "Male", from_amount: 7501, to_amount: 10000, tax_amount: 175 },
+    { gender: "Male", from_amount: 10001, to_amount: null, tax_amount: 200 },
+    { gender: "Female", from_amount: 0, to_amount: 25000, tax_amount: 0 },
+    { gender: "Female", from_amount: 25001, to_amount: null, tax_amount: 200 },
+];
+
+function parse_pt_slabs(row) {
+    try {
+        const arr = JSON.parse(row.slabs || "[]");
+        return Array.isArray(arr) ? arr : [];
+    } catch (e) {
+        return [];
+    }
+}
+
+function _pt_slab_summary(slabs) {
+    if (!slabs.length) {
+        return `<span style="color:#ccc;font-size:11px">—</span>`;
+    }
+    return slabs.map(s => {
+        const to = s.to_amount == null || s.to_amount === "" ? "∞" : s.to_amount;
+        return `<span style="display:inline-block;background:#f3e5f5;border:0.5px solid #7b1fa255;
+            color:#4a148c;border-radius:3px;padding:2px 8px;font-size:11px;margin:1px 2px 1px 0">
+            ${frappe.utils.escape_html(s.gender)}: ₹${s.from_amount}–${to} → ₹${s.tax_amount}
+        </span>`;
+    }).join("");
+}
+
+function _pt_slab_editor_html(slabs) {
+    const rows = (slabs && slabs.length ? slabs : [{}]).map((s, i) => `
+        <tr data-slab-idx="${i}">
+            <td style="padding:4px">
+                <select class="pt-slab-gender" style="width:100%;font-size:12px;padding:4px;border:0.5px solid #ccc;border-radius:4px">
+                    <option value="Male" ${s.gender === "Male" ? "selected" : ""}>Male</option>
+                    <option value="Female" ${s.gender === "Female" ? "selected" : ""}>Female</option>
+                </select>
+            </td>
+            <td style="padding:4px">
+                <input type="number" class="pt-slab-from" value="${s.from_amount ?? ""}"
+                    style="width:100%;font-size:12px;padding:4px;border:0.5px solid #ccc;border-radius:4px;box-sizing:border-box">
+            </td>
+            <td style="padding:4px">
+                <input type="number" class="pt-slab-to" value="${s.to_amount == null ? "" : s.to_amount}"
+                    placeholder="open"
+                    style="width:100%;font-size:12px;padding:4px;border:0.5px solid #ccc;border-radius:4px;box-sizing:border-box">
+            </td>
+            <td style="padding:4px">
+                <input type="number" class="pt-slab-tax" value="${s.tax_amount ?? ""}"
+                    style="width:100%;font-size:12px;padding:4px;border:0.5px solid #ccc;border-radius:4px;box-sizing:border-box">
+            </td>
+            <td style="padding:4px;text-align:center">
+                <span class="pt-remove-slab" style="cursor:pointer;color:#e53935;font-size:13px" title="Remove">✕</span>
+            </td>
+        </tr>`).join("");
+
+    return `
+        <table style="width:100%;border-collapse:collapse;margin-bottom:6px">
+            <thead><tr style="background:#f5f5f5">
+                <th style="padding:4px 6px;font-size:11px;color:#666;text-align:left">Gender</th>
+                <th style="padding:4px 6px;font-size:11px;color:#666;text-align:left">From (₹)</th>
+                <th style="padding:4px 6px;font-size:11px;color:#666;text-align:left">To (₹)</th>
+                <th style="padding:4px 6px;font-size:11px;color:#666;text-align:left">Tax (₹)</th>
+                <th style="width:28px"></th>
+            </tr></thead>
+            <tbody class="pt-slab-tbody">${rows}</tbody>
+        </table>
+        <button type="button" class="pt-add-slab"
+            style="padding:3px 8px;font-size:11px;border:0.5px dashed #aaa;border-radius:4px;
+                   background:transparent;cursor:pointer;color:#6a1b9a">+ Add Slab</button>`;
+}
+
+function _collect_pt_slabs($form) {
+    const slabs = [];
+    $form.find(".pt-slab-tbody tr").each(function () {
+        const $tr = $(this);
+        const toVal = $tr.find(".pt-slab-to").val().trim();
+        slabs.push({
+            gender: $tr.find(".pt-slab-gender").val() || "Male",
+            from_amount: parseFloat($tr.find(".pt-slab-from").val()) || 0,
+            to_amount: toVal === "" ? null : parseFloat(toVal),
+            tax_amount: parseFloat($tr.find(".pt-slab-tax").val()) || 0,
+        });
+    });
+    return slabs;
+}
+
+function render_pt_period_ui(frm) {
+    _fetch_ssa_dates(frm).then(ssa_dates => {
+        const fieldname = "pt_periods";
+        const field = frm.fields_dict[fieldname];
+        if (!field) return;
+
+        field.grid.wrapper.hide();
+        const $wrapper = field.$wrapper;
+        const uid = `${fieldname}-period-ui`;
+        $wrapper.find(`#${uid}`).remove();
+
+        const border_color = "#6a1b9a";
+        const bg_color = "#f3e5f5";
+        const text_color = "#4a148c";
+        const rows = frm.doc[fieldname] || [];
+
+        let tbody_html = "";
+        rows.forEach((row, i) => {
+            const slabs = parse_pt_slabs(row);
+            const locked = _is_period_locked(row, ssa_dates);
+            const action_html = locked
+                ? `<span style="color:#f59e0b;font-size:14px;margin-right:4px"
+                       title="Locked — Salary Structure Assignment exists">🔒</span>
+                   <span class="edit-todate" data-idx="${i}"
+                       style="cursor:pointer;color:${border_color};font-size:13px"
+                       title="Edit To Date only">✏</span>`
+                : `<span class="edit-period" data-idx="${i}"
+                       style="cursor:pointer;color:${border_color};font-size:13px;margin-right:6px"
+                       title="Edit">✏</span>
+                   <span class="delete-period" data-idx="${i}"
+                       style="cursor:pointer;color:#e53935;font-size:13px"
+                       title="Delete">✕</span>`;
+            const row_bg = locked ? "background:#fffbeb" : "";
+            tbody_html += `
+            <tr style="${row_bg}">
+                <td style="padding:6px 8px;border:0.5px solid #e0e0e0;color:#999;font-size:12px;vertical-align:top">${i + 1}</td>
+                <td style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:12px;white-space:nowrap;vertical-align:top">${to_display(row.from_date) || "—"}</td>
+                <td style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:12px;white-space:nowrap;vertical-align:top">${to_display(row.to_date) || "—"}</td>
+                <td style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:12px;vertical-align:top">₹${parseFloat(row.february_amount || 0).toLocaleString("en-IN")}</td>
+                <td style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:12px;vertical-align:top">${row.age_exempt_years || 65}</td>
+                <td style="padding:6px 8px;border:0.5px solid #e0e0e0;vertical-align:top">${_pt_slab_summary(slabs)}</td>
+                <td style="padding:6px 8px;border:0.5px solid #e0e0e0;text-align:center;white-space:nowrap;vertical-align:top">${action_html}</td>
+            </tr>`;
+        });
+
+        const table_html = tbody_html
+            ? `<table style="width:100%;border-collapse:collapse;margin-bottom:6px">
+                <thead><tr style="background:#f5f5f5">
+                    <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666;width:36px">No.</th>
+                    <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666;width:100px">From</th>
+                    <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666;width:100px">To</th>
+                    <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666;width:90px">Feb Amt</th>
+                    <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666;width:70px">Age Exempt</th>
+                    <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666">Slabs</th>
+                    <th style="padding:6px 8px;border:0.5px solid #e0e0e0;width:55px"></th>
+                </tr></thead>
+                <tbody>${tbody_html}</tbody>
+               </table>`
+            : `<div style="font-size:12px;color:#999;margin-bottom:8px">No Professional Tax periods configured yet.</div>`;
+
+        const $ui = $(`
+        <div id="${uid}" style="margin:8px 0 12px 0">
+            <div style="font-size:12px;color:#6c757d;margin-bottom:8px">
+                Configure Maharashtra (or custom) Professional Tax slabs by period. Tax is computed from final gross, employee gender, and age.
+            </div>
+            <div class="period-table-wrap">${table_html}</div>
+
+            <button class="add-period-btn"
+                style="display:flex;align-items:center;gap:5px;padding:5px 10px;
+                       border:0.5px dashed #aaa;border-radius:5px;color:${border_color};
+                       font-size:12px;cursor:pointer;background:transparent;margin-top:4px">
+                + New Professional Tax Period
+            </button>
+
+            <div class="add-period-form" style="display:none;border:1.5px solid ${border_color};
+                 border-radius:7px;padding:14px 16px;margin-top:8px;background:#fff">
+
+                <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">
+                    <div style="font-size:12px;font-weight:600;color:${border_color}">
+                        New Professional Tax Period
+                    </div>
+                    <button type="button" class="pt-load-defaults"
+                        style="padding:4px 10px;font-size:11px;border:0.5px solid ${border_color};
+                               border-radius:4px;background:${bg_color};color:${text_color};cursor:pointer">
+                        Load Maharashtra defaults
+                    </button>
+                </div>
+
+                <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:12px">
+                    <div>
+                        <div style="font-size:11px;color:#888;margin-bottom:3px">From Date</div>
+                        <input type="text" class="period-from-date" placeholder="DD-MM-YYYY"
+                            style="width:100%;border:0.5px solid #ccc;border-radius:4px;
+                                   padding:5px 8px;font-size:12px;box-sizing:border-box">
+                    </div>
+                    <div>
+                        <div style="font-size:11px;color:#888;margin-bottom:3px">To Date</div>
+                        <input type="text" class="period-to-date" placeholder="DD-MM-YYYY"
+                            style="width:100%;border:0.5px solid #ccc;border-radius:4px;
+                                   padding:5px 8px;font-size:12px;box-sizing:border-box">
+                    </div>
+                </div>
+
+                <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:12px">
+                    <div>
+                        <div style="font-size:11px;color:#888;margin-bottom:3px">February Amount (₹)</div>
+                        <input type="number" class="pt-february-amount" value="300"
+                            style="width:100%;border:0.5px solid #ccc;border-radius:4px;
+                                   padding:5px 8px;font-size:12px;box-sizing:border-box">
+                    </div>
+                    <div>
+                        <div style="font-size:11px;color:#888;margin-bottom:3px">Age Exempt Years</div>
+                        <input type="number" class="pt-age-exempt" value="65"
+                            style="width:100%;border:0.5px solid #ccc;border-radius:4px;
+                                   padding:5px 8px;font-size:12px;box-sizing:border-box">
+                    </div>
+                </div>
+
+                <div style="border:0.5px solid ${border_color}44;border-radius:5px;
+                            padding:10px 12px;margin-bottom:12px;background:${bg_color}55">
+                    <div style="font-size:11px;font-weight:600;color:${text_color};margin-bottom:8px">
+                        Gender Slabs
+                    </div>
+                    <div class="pt-slab-editor">${_pt_slab_editor_html(MAHARASHTRA_PT_SLABS)}</div>
+                </div>
+
+                <div style="display:flex;gap:8px;justify-content:flex-end">
+                    <button class="cancel-period-btn"
+                        style="padding:5px 13px;border-radius:4px;font-size:12px;cursor:pointer;
+                               border:0.5px solid #ccc;background:transparent;color:#666">Cancel</button>
+                    <button class="save-period-btn"
+                        style="padding:5px 13px;border-radius:4px;font-size:12px;cursor:pointer;
+                               border:0.5px solid ${border_color};background:${border_color};color:#fff">
+                        Save Period</button>
+                </div>
+            </div>
+        </div>`);
+
+        $wrapper.append($ui);
+
+        $ui.find(".period-from-date, .period-to-date").datepicker({
+            language: frappe.boot.lang || "en",
+            autoClose: true,
+            dateFormat: "dd-mm-yyyy"
+        });
+
+        function refresh_slab_editor(slabs) {
+            $ui.find(".pt-slab-editor").html(_pt_slab_editor_html(slabs));
+            bind_slab_editor();
+        }
+
+        function bind_slab_editor() {
+            $ui.find(".pt-add-slab").off("click").on("click", function () {
+                const slabs = _collect_pt_slabs($ui);
+                slabs.push({ gender: "Male", from_amount: 0, to_amount: null, tax_amount: 0 });
+                refresh_slab_editor(slabs);
+            });
+            $ui.find(".pt-remove-slab").off("click").on("click", function () {
+                const idx = parseInt($(this).closest("tr").data("slab-idx"));
+                const slabs = _collect_pt_slabs($ui);
+                slabs.splice(idx, 1);
+                refresh_slab_editor(slabs.length ? slabs : [{}]);
+            });
+        }
+        bind_slab_editor();
+
+        $ui.find(".add-period-btn").on("click", function () {
+            $(this).hide();
+            $ui.find(".add-period-form").slideDown(150);
+        });
+
+        $ui.find(".cancel-period-btn").on("click", () => {
+            $ui.find(".add-period-form").slideUp(150, function () {
+                $ui.find(".add-period-btn").show();
+                $ui.find(".period-from-date, .period-to-date").val("");
+                $ui.find(".pt-february-amount").val(300);
+                $ui.find(".pt-age-exempt").val(65);
+                refresh_slab_editor(MAHARASHTRA_PT_SLABS);
+            });
+        });
+
+        $ui.find(".pt-load-defaults").on("click", function () {
+            $ui.find(".pt-february-amount").val(300);
+            $ui.find(".pt-age-exempt").val(65);
+            refresh_slab_editor(MAHARASHTRA_PT_SLABS);
+            frappe.show_alert({ message: __("Maharashtra defaults loaded"), indicator: "green" });
+        });
+
+        $ui.find(".save-period-btn").on("click", function () {
+            const slabs = _collect_pt_slabs($ui);
+            if (!slabs.length) {
+                frappe.msgprint(__("Please add at least one slab."));
+                return;
+            }
+            const row = frappe.model.add_child(frm.doc, "Professional Tax Period", fieldname);
+            row.from_date = to_backend($ui.find(".period-from-date").val().trim()) || null;
+            row.to_date = to_backend($ui.find(".period-to-date").val().trim()) || null;
+            row.february_amount = parseFloat($ui.find(".pt-february-amount").val()) || 0;
+            row.age_exempt_years = parseInt($ui.find(".pt-age-exempt").val(), 10) || 65;
+            row.slabs = JSON.stringify(slabs);
+            frm.dirty();
+            frm.refresh_field(fieldname);
+            render_pt_period_ui(frm);
+        });
+
+        $ui.find(".delete-period").on("click", function () {
+            const idx = parseInt($(this).data("idx"));
+            frappe.confirm(__("Delete this Professional Tax period?"), () => {
+                frm.doc[fieldname].splice(idx, 1);
+                frm.dirty();
+                frm.refresh_field(fieldname);
+                render_pt_period_ui(frm);
+            });
+        });
+
+        $ui.find(".edit-period").on("click", function () {
+            const idx = parseInt($(this).data("idx"));
+            const row = (frm.doc[fieldname] || [])[idx];
+            if (!row) return;
+            const slabs = parse_pt_slabs(row);
+            frm.doc[fieldname].splice(idx, 1);
+            frm.refresh_field(fieldname);
+
+            $ui.find(".period-from-date").val(to_display(row.from_date));
+            $ui.find(".period-to-date").val(to_display(row.to_date));
+            $ui.find(".pt-february-amount").val(row.february_amount != null ? row.february_amount : 300);
+            $ui.find(".pt-age-exempt").val(row.age_exempt_years != null ? row.age_exempt_years : 65);
+            refresh_slab_editor(slabs.length ? slabs : MAHARASHTRA_PT_SLABS);
+
+            $ui.find(".add-period-btn").hide();
+            $ui.find(".add-period-form").slideDown(150);
+        });
+
+        $ui.find(".edit-todate").on("click", function () {
+            const idx = parseInt($(this).data("idx"));
+            const row = (frm.doc[fieldname] || [])[idx];
+            if (!row) return;
+            frappe.prompt(
+                [{
+                    label: __("To Date"),
+                    fieldname: "to_date",
+                    fieldtype: "Date",
+                    default: row.to_date || ""
+                }],
+                (values) => {
+                    row.to_date = values.to_date || null;
+                    frm.dirty();
+                    frm.refresh_field(fieldname);
+                    render_pt_period_ui(frm);
+                },
+                __("Edit To Date — Professional Tax Period"),
+                __("Update")
+            );
+        });
     });
 }
 

--- a/saral_hr/saral_hr/doctype/company/company.js
+++ b/saral_hr/saral_hr/doctype/company/company.js
@@ -494,11 +494,11 @@ function _reset_form($ui) {
 // ─────────────────────────────────────────────────────────────
 
 const MAHARASHTRA_PT_SLABS = [
-    { gender: "Male", from_amount: 0, to_amount: 7500, tax_amount: 0 },
-    { gender: "Male", from_amount: 7501, to_amount: 10000, tax_amount: 175 },
-    { gender: "Male", from_amount: 10001, to_amount: null, tax_amount: 200 },
-    { gender: "Female", from_amount: 0, to_amount: 25000, tax_amount: 0 },
-    { gender: "Female", from_amount: 25001, to_amount: null, tax_amount: 200 },
+    { gender: "Male", from_amount: 0, to_amount: 7500, tax_amount: 0, february_amount: null },
+    { gender: "Male", from_amount: 7501, to_amount: 10000, tax_amount: 175, february_amount: 275 },
+    { gender: "Male", from_amount: 10001, to_amount: null, tax_amount: 200, february_amount: 300 },
+    { gender: "Female", from_amount: 0, to_amount: 25000, tax_amount: 0, february_amount: null },
+    { gender: "Female", from_amount: 25001, to_amount: null, tax_amount: 200, february_amount: null },
 ];
 
 function parse_pt_slabs(row) {
@@ -516,9 +516,12 @@ function _pt_slab_summary(slabs) {
     }
     return slabs.map(s => {
         const to = s.to_amount == null || s.to_amount === "" ? "∞" : s.to_amount;
+        const feb = s.february_amount == null || s.february_amount === ""
+            ? ""
+            : ` (Feb ₹${s.february_amount})`;
         return `<span style="display:inline-block;background:#f3e5f5;border:0.5px solid #7b1fa255;
             color:#4a148c;border-radius:3px;padding:2px 8px;font-size:11px;margin:1px 2px 1px 0">
-            ${frappe.utils.escape_html(s.gender)}: ₹${s.from_amount}–${to} → ₹${s.tax_amount}
+            ${frappe.utils.escape_html(s.gender)}: ₹${s.from_amount}–${to} → ₹${s.tax_amount}${feb}
         </span>`;
     }).join("");
 }
@@ -545,6 +548,11 @@ function _pt_slab_editor_html(slabs) {
                 <input type="number" class="pt-slab-tax" value="${s.tax_amount ?? ""}"
                     style="width:100%;font-size:12px;padding:4px;border:0.5px solid #ccc;border-radius:4px;box-sizing:border-box">
             </td>
+            <td style="padding:4px">
+                <input type="number" class="pt-slab-feb" value="${s.february_amount == null ? "" : s.february_amount}"
+                    placeholder="—"
+                    style="width:100%;font-size:12px;padding:4px;border:0.5px solid #ccc;border-radius:4px;box-sizing:border-box">
+            </td>
             <td style="padding:4px;text-align:center">
                 <span class="pt-remove-slab" style="cursor:pointer;color:#e53935;font-size:13px" title="Remove">✕</span>
             </td>
@@ -557,6 +565,7 @@ function _pt_slab_editor_html(slabs) {
                 <th style="padding:4px 6px;font-size:11px;color:#666;text-align:left">From (₹)</th>
                 <th style="padding:4px 6px;font-size:11px;color:#666;text-align:left">To (₹)</th>
                 <th style="padding:4px 6px;font-size:11px;color:#666;text-align:left">Tax (₹)</th>
+                <th style="padding:4px 6px;font-size:11px;color:#666;text-align:left">Feb (₹)</th>
                 <th style="width:28px"></th>
             </tr></thead>
             <tbody class="pt-slab-tbody">${rows}</tbody>
@@ -571,11 +580,13 @@ function _collect_pt_slabs($form) {
     $form.find(".pt-slab-tbody tr").each(function () {
         const $tr = $(this);
         const toVal = $tr.find(".pt-slab-to").val().trim();
+        const febVal = $tr.find(".pt-slab-feb").val().trim();
         slabs.push({
             gender: $tr.find(".pt-slab-gender").val() || "Male",
             from_amount: parseFloat($tr.find(".pt-slab-from").val()) || 0,
             to_amount: toVal === "" ? null : parseFloat(toVal),
             tax_amount: parseFloat($tr.find(".pt-slab-tax").val()) || 0,
+            february_amount: febVal === "" ? null : parseFloat(febVal),
         });
     });
     return slabs;
@@ -619,7 +630,6 @@ function render_pt_period_ui(frm) {
                 <td style="padding:6px 8px;border:0.5px solid #e0e0e0;color:#999;font-size:12px;vertical-align:top">${i + 1}</td>
                 <td style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:12px;white-space:nowrap;vertical-align:top">${to_display(row.from_date) || "—"}</td>
                 <td style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:12px;white-space:nowrap;vertical-align:top">${to_display(row.to_date) || "—"}</td>
-                <td style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:12px;vertical-align:top">₹${parseFloat(row.february_amount || 0).toLocaleString("en-IN")}</td>
                 <td style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:12px;vertical-align:top">${row.age_exempt_years || 65}</td>
                 <td style="padding:6px 8px;border:0.5px solid #e0e0e0;vertical-align:top">${_pt_slab_summary(slabs)}</td>
                 <td style="padding:6px 8px;border:0.5px solid #e0e0e0;text-align:center;white-space:nowrap;vertical-align:top">${action_html}</td>
@@ -632,7 +642,6 @@ function render_pt_period_ui(frm) {
                     <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666;width:36px">No.</th>
                     <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666;width:100px">From</th>
                     <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666;width:100px">To</th>
-                    <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666;width:90px">Feb Amt</th>
                     <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666;width:70px">Age Exempt</th>
                     <th style="padding:6px 8px;border:0.5px solid #e0e0e0;font-size:11px;font-weight:500;color:#666">Slabs</th>
                     <th style="padding:6px 8px;border:0.5px solid #e0e0e0;width:55px"></th>
@@ -644,7 +653,7 @@ function render_pt_period_ui(frm) {
         const $ui = $(`
         <div id="${uid}" style="margin:8px 0 12px 0">
             <div style="font-size:12px;color:#6c757d;margin-bottom:8px">
-                Configure Maharashtra (or custom) Professional Tax slabs by period. Tax is computed from final gross, employee gender, and age.
+                Configure Maharashtra (or custom) Professional Tax slabs by period. Optional February amount is per slab (Female taxable has none).
             </div>
             <div class="period-table-wrap">${table_html}</div>
 
@@ -669,7 +678,7 @@ function render_pt_period_ui(frm) {
                     </button>
                 </div>
 
-                <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:12px">
+                <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;margin-bottom:12px">
                     <div>
                         <div style="font-size:11px;color:#888;margin-bottom:3px">From Date</div>
                         <input type="text" class="period-from-date" placeholder="DD-MM-YYYY"
@@ -679,15 +688,6 @@ function render_pt_period_ui(frm) {
                     <div>
                         <div style="font-size:11px;color:#888;margin-bottom:3px">To Date</div>
                         <input type="text" class="period-to-date" placeholder="DD-MM-YYYY"
-                            style="width:100%;border:0.5px solid #ccc;border-radius:4px;
-                                   padding:5px 8px;font-size:12px;box-sizing:border-box">
-                    </div>
-                </div>
-
-                <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:12px">
-                    <div>
-                        <div style="font-size:11px;color:#888;margin-bottom:3px">February Amount (₹)</div>
-                        <input type="number" class="pt-february-amount" value="300"
                             style="width:100%;border:0.5px solid #ccc;border-radius:4px;
                                    padding:5px 8px;font-size:12px;box-sizing:border-box">
                     </div>
@@ -735,7 +735,7 @@ function render_pt_period_ui(frm) {
         function bind_slab_editor() {
             $ui.find(".pt-add-slab").off("click").on("click", function () {
                 const slabs = _collect_pt_slabs($ui);
-                slabs.push({ gender: "Male", from_amount: 0, to_amount: null, tax_amount: 0 });
+                slabs.push({ gender: "Male", from_amount: 0, to_amount: null, tax_amount: 0, february_amount: null });
                 refresh_slab_editor(slabs);
             });
             $ui.find(".pt-remove-slab").off("click").on("click", function () {
@@ -756,14 +756,12 @@ function render_pt_period_ui(frm) {
             $ui.find(".add-period-form").slideUp(150, function () {
                 $ui.find(".add-period-btn").show();
                 $ui.find(".period-from-date, .period-to-date").val("");
-                $ui.find(".pt-february-amount").val(300);
                 $ui.find(".pt-age-exempt").val(65);
                 refresh_slab_editor(MAHARASHTRA_PT_SLABS);
             });
         });
 
         $ui.find(".pt-load-defaults").on("click", function () {
-            $ui.find(".pt-february-amount").val(300);
             $ui.find(".pt-age-exempt").val(65);
             refresh_slab_editor(MAHARASHTRA_PT_SLABS);
             frappe.show_alert({ message: __("Maharashtra defaults loaded"), indicator: "green" });
@@ -778,7 +776,6 @@ function render_pt_period_ui(frm) {
             const row = frappe.model.add_child(frm.doc, "Professional Tax Period", fieldname);
             row.from_date = to_backend($ui.find(".period-from-date").val().trim()) || null;
             row.to_date = to_backend($ui.find(".period-to-date").val().trim()) || null;
-            row.february_amount = parseFloat($ui.find(".pt-february-amount").val()) || 0;
             row.age_exempt_years = parseInt($ui.find(".pt-age-exempt").val(), 10) || 65;
             row.slabs = JSON.stringify(slabs);
             frm.dirty();
@@ -806,7 +803,6 @@ function render_pt_period_ui(frm) {
 
             $ui.find(".period-from-date").val(to_display(row.from_date));
             $ui.find(".period-to-date").val(to_display(row.to_date));
-            $ui.find(".pt-february-amount").val(row.february_amount != null ? row.february_amount : 300);
             $ui.find(".pt-age-exempt").val(row.age_exempt_years != null ? row.age_exempt_years : 65);
             refresh_slab_editor(slabs.length ? slabs : MAHARASHTRA_PT_SLABS);
 

--- a/saral_hr/saral_hr/doctype/company/company.json
+++ b/saral_hr/saral_hr/doctype/company/company.json
@@ -47,6 +47,8 @@
   "esic_dependent_component",
   "section_pf_components",
   "pf_dependent_component",
+  "section_pt_slabs",
+  "pt_periods",
   "headcount_tab",
   "no_of_staff",
   "no_of_workers",
@@ -265,6 +267,17 @@
    "options": "Statutory Wage Component"
   },
   {
+   "fieldname": "section_pt_slabs",
+   "fieldtype": "Section Break",
+   "label": "Professional Tax Slabs"
+  },
+  {
+   "fieldname": "pt_periods",
+   "fieldtype": "Table",
+   "label": "Professional Tax Periods",
+   "options": "Professional Tax Period"
+  },
+  {
    "fieldname": "headcount_tab",
    "fieldtype": "Tab Break",
    "label": "Headcount"
@@ -317,7 +330,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-08-02 08:00:00.000000",
+ "modified": "2026-08-04 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Saral Hr",
  "name": "Company",

--- a/saral_hr/saral_hr/doctype/company/company.py
+++ b/saral_hr/saral_hr/doctype/company/company.py
@@ -10,14 +10,13 @@ from frappe.utils import cint, flt, getdate
 VIRTUAL_COMPONENTS = {"Gross", "Gross Including Additional Salary"}
 
 MAHARASHTRA_PT_SLABS = [
-	{"gender": "Male", "from_amount": 0, "to_amount": 7500, "tax_amount": 0},
-	{"gender": "Male", "from_amount": 7501, "to_amount": 10000, "tax_amount": 175},
-	{"gender": "Male", "from_amount": 10001, "to_amount": None, "tax_amount": 200},
-	{"gender": "Female", "from_amount": 0, "to_amount": 25000, "tax_amount": 0},
-	{"gender": "Female", "from_amount": 25001, "to_amount": None, "tax_amount": 200},
+	{"gender": "Male", "from_amount": 0, "to_amount": 7500, "tax_amount": 0, "february_amount": None},
+	{"gender": "Male", "from_amount": 7501, "to_amount": 10000, "tax_amount": 175, "february_amount": 275},
+	{"gender": "Male", "from_amount": 10001, "to_amount": None, "tax_amount": 200, "february_amount": 300},
+	{"gender": "Female", "from_amount": 0, "to_amount": 25000, "tax_amount": 0, "february_amount": None},
+	{"gender": "Female", "from_amount": 25001, "to_amount": None, "tax_amount": 200, "february_amount": None},
 ]
 
-DEFAULT_PT_FEBRUARY_AMOUNT = 300.0
 DEFAULT_PT_AGE_EXEMPT_YEARS = 65
 
 
@@ -73,7 +72,6 @@ def seed_pt_period_on_company(company_name: str) -> bool:
 		{
 			"from_date": None,
 			"to_date": None,
-			"february_amount": DEFAULT_PT_FEBRUARY_AMOUNT,
 			"age_exempt_years": DEFAULT_PT_AGE_EXEMPT_YEARS,
 			"slabs": maharashtra_pt_slabs_json(),
 		},
@@ -100,7 +98,7 @@ class Company(Document):
 		)
 		self._validate_locked_periods(
 			"pt_periods", "Professional Tax",
-			["slabs", "february_amount", "age_exempt_years", "from_date"]
+			["slabs", "age_exempt_years", "from_date"]
 		)
 
 	def on_update(self):
@@ -143,10 +141,6 @@ class Company(Document):
 		rows = list(self.get("pt_periods") or [])
 		self._validate_pt_period_overlap(rows)
 		for row in rows:
-			if flt(row.get("february_amount")) < 0:
-				frappe.throw(
-					_("Professional Tax February Amount cannot be negative (row {0}).").format(row.idx)
-				)
 			if cint(row.get("age_exempt_years")) < 0:
 				frappe.throw(
 					_("Professional Tax Age Exempt Years cannot be negative (row {0}).").format(row.idx)
@@ -188,11 +182,23 @@ class Company(Document):
 			from_amount = flt(slab.get("from_amount"))
 			to_raw = slab.get("to_amount")
 			tax_amount = flt(slab.get("tax_amount"))
+			feb_raw = slab.get("february_amount")
 			if from_amount < 0 or tax_amount < 0:
 				frappe.throw(
 					_("Professional Tax slab {0} in period row {1}: amounts cannot be negative.")
 					.format(i + 1, row_idx)
 				)
+			if feb_raw is not None and feb_raw != "":
+				if flt(feb_raw) < 0:
+					frappe.throw(
+						_("Professional Tax slab {0} in period row {1}: February Amount cannot be negative.")
+						.format(i + 1, row_idx)
+					)
+				if tax_amount == 0:
+					frappe.throw(
+						_("Professional Tax slab {0} in period row {1}: February Amount is not allowed when Tax is 0.")
+						.format(i + 1, row_idx)
+					)
 			if to_raw is not None and to_raw != "":
 				to_amount = flt(to_raw)
 				if to_amount < 0:
@@ -415,7 +421,6 @@ class Company(Document):
 		if not row:
 			return None
 		return {
-			"february_amount": flt(row.february_amount) if row.february_amount is not None else DEFAULT_PT_FEBRUARY_AMOUNT,
 			"age_exempt_years": cint(row.age_exempt_years) if row.age_exempt_years is not None else DEFAULT_PT_AGE_EXEMPT_YEARS,
 			"slabs": self._parse_slabs(row),
 			"from_date": row.from_date,
@@ -436,8 +441,7 @@ class Company(Document):
 
 		resolved_gender = gender if gender in ("Male", "Female") else "Male"
 		gross_amt = flt(gross)
-		tax = 0.0
-		matched = False
+		matched_slab = None
 		for slab in cfg.get("slabs") or []:
 			if slab.get("gender") != resolved_gender:
 				continue
@@ -447,13 +451,17 @@ class Company(Document):
 				to_raw is None or to_raw == "" or gross_amt <= flt(to_raw)
 			)
 			if in_range:
-				tax = flt(slab.get("tax_amount"))
-				matched = True
+				matched_slab = slab
 				break
 
-		if not matched:
+		if not matched_slab:
 			return 0.0
 
-		if period_date and getdate(period_date).month == 2 and tax > 0:
-			return flt(cfg.get("february_amount"))
+		tax = flt(matched_slab.get("tax_amount"))
+		if tax == 0:
+			return 0.0
+
+		feb_raw = matched_slab.get("february_amount")
+		if period_date and getdate(period_date).month == 2 and feb_raw is not None and feb_raw != "":
+			return flt(feb_raw)
 		return tax

--- a/saral_hr/saral_hr/doctype/company/company.py
+++ b/saral_hr/saral_hr/doctype/company/company.py
@@ -5,9 +5,24 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt, getdate
+from frappe.utils import cint, flt, getdate
 
 VIRTUAL_COMPONENTS = {"Gross", "Gross Including Additional Salary"}
+
+MAHARASHTRA_PT_SLABS = [
+	{"gender": "Male", "from_amount": 0, "to_amount": 7500, "tax_amount": 0},
+	{"gender": "Male", "from_amount": 7501, "to_amount": 10000, "tax_amount": 175},
+	{"gender": "Male", "from_amount": 10001, "to_amount": None, "tax_amount": 200},
+	{"gender": "Female", "from_amount": 0, "to_amount": 25000, "tax_amount": 0},
+	{"gender": "Female", "from_amount": 25001, "to_amount": None, "tax_amount": 200},
+]
+
+DEFAULT_PT_FEBRUARY_AMOUNT = 300.0
+DEFAULT_PT_AGE_EXEMPT_YEARS = 65
+
+
+def maharashtra_pt_slabs_json() -> str:
+	return json.dumps(MAHARASHTRA_PT_SLABS)
 
 
 def update_company_employee_counts(company: str | None) -> None:
@@ -46,228 +61,399 @@ def backfill_all_company_employee_counts() -> None:
 		update_company_employee_counts(name)
 
 
+def seed_pt_period_on_company(company_name: str) -> bool:
+	"""Append one open Maharashtra PT period when company has none. Returns True if seeded."""
+	if not company_name or not frappe.db.exists("Company", company_name):
+		return False
+	doc = frappe.get_doc("Company", company_name)
+	if doc.get("pt_periods"):
+		return False
+	doc.append(
+		"pt_periods",
+		{
+			"from_date": None,
+			"to_date": None,
+			"february_amount": DEFAULT_PT_FEBRUARY_AMOUNT,
+			"age_exempt_years": DEFAULT_PT_AGE_EXEMPT_YEARS,
+			"slabs": maharashtra_pt_slabs_json(),
+		},
+	)
+	doc.save(ignore_permissions=True)
+	return True
+
+
 class Company(Document):
 
-    def validate(self):
-        self.validate_esic_settings()
-        self.validate_pf_settings()
-        # ── CHANGED: to_date removed from protected_fields so it stays editable on locked rows ──
-        self._validate_locked_periods(
-            "esic_dependent_component", "ESIC",
-            ["wage_components", "esic_wage_limit", "employee_contribution", "employer_contribution"]
-        )
-        self._validate_locked_periods(
-            "pf_dependent_component", "PF",
-            ["wage_components", "pf_wage_limit", "employee_percent",
-             "employer_epf", "employer_eps", "edli_insurance", "admin_charges"]
-        )
+	def validate(self):
+		self.validate_esic_settings()
+		self.validate_pf_settings()
+		self.validate_pt_settings()
+		# to_date excluded from protected_fields so it stays editable on locked rows
+		self._validate_locked_periods(
+			"esic_dependent_component", "ESIC",
+			["wage_components", "esic_wage_limit", "employee_contribution", "employer_contribution"]
+		)
+		self._validate_locked_periods(
+			"pf_dependent_component", "PF",
+			["wage_components", "pf_wage_limit", "employee_percent",
+			 "employer_epf", "employer_eps", "edli_insurance", "admin_charges"]
+		)
+		self._validate_locked_periods(
+			"pt_periods", "Professional Tax",
+			["slabs", "february_amount", "age_exempt_years", "from_date"]
+		)
 
-    def on_update(self):
-        pass
+	def on_update(self):
+		pass
 
-    # ──────────────────────────────────────────────
-    # Validate
-    # ──────────────────────────────────────────────
+	# ──────────────────────────────────────────────
+	# Validate
+	# ──────────────────────────────────────────────
 
-    def validate_esic_settings(self):
-        for row in (self.get("esic_dependent_component") or []):
-            comps = self._parse_components(row)
-            if comps:
-                self._validate_components(comps, "ESIC")
-            for field, lbl in [
-                ("esic_wage_limit",      "ESIC Wage Limit"),
-                ("employee_contribution","Employee Contribution %"),
-                ("employer_contribution","Employer Contribution %"),
-            ]:
-                if flt(row.get(field)) < 0:
-                    frappe.throw(_("ESIC {0} cannot be negative (row {1}).").format(lbl, row.idx))
+	def validate_esic_settings(self):
+		for row in (self.get("esic_dependent_component") or []):
+			comps = self._parse_components(row)
+			if comps:
+				self._validate_components(comps, "ESIC")
+			for field, lbl in [
+				("esic_wage_limit",      "ESIC Wage Limit"),
+				("employee_contribution","Employee Contribution %"),
+				("employer_contribution","Employer Contribution %"),
+			]:
+				if flt(row.get(field)) < 0:
+					frappe.throw(_("ESIC {0} cannot be negative (row {1}).").format(lbl, row.idx))
 
-    def validate_pf_settings(self):
-        for row in (self.get("pf_dependent_component") or []):
-            comps = self._parse_components(row)
-            if comps:
-                self._validate_components(comps, "PF")
-            for field, lbl in [
-                ("pf_wage_limit",   "PF Wage Limit"),
-                ("employee_percent","Employee PF %"),
-                ("employer_epf",    "Employer EPF %"),
-                ("employer_eps",    "Employer EPS %"),
-                ("edli_insurance",  "EDLI Insurance %"),
-                ("admin_charges",   "Admin Charges %"),
-            ]:
-                if flt(row.get(field)) < 0:
-                    frappe.throw(_("PF {0} cannot be negative (row {1}).").format(lbl, row.idx))
+	def validate_pf_settings(self):
+		for row in (self.get("pf_dependent_component") or []):
+			comps = self._parse_components(row)
+			if comps:
+				self._validate_components(comps, "PF")
+			for field, lbl in [
+				("pf_wage_limit",   "PF Wage Limit"),
+				("employee_percent","Employee PF %"),
+				("employer_epf",    "Employer EPF %"),
+				("employer_eps",    "Employer EPS %"),
+				("edli_insurance",  "EDLI Insurance %"),
+				("admin_charges",   "Admin Charges %"),
+			]:
+				if flt(row.get(field)) < 0:
+					frappe.throw(_("PF {0} cannot be negative (row {1}).").format(lbl, row.idx))
 
-    # ──────────────────────────────────────────────
-    # Lock validation — SSA exists → cannot edit period
-    # ──────────────────────────────────────────────
+	def validate_pt_settings(self):
+		rows = list(self.get("pt_periods") or [])
+		self._validate_pt_period_overlap(rows)
+		for row in rows:
+			if flt(row.get("february_amount")) < 0:
+				frappe.throw(
+					_("Professional Tax February Amount cannot be negative (row {0}).").format(row.idx)
+				)
+			if cint(row.get("age_exempt_years")) < 0:
+				frappe.throw(
+					_("Professional Tax Age Exempt Years cannot be negative (row {0}).").format(row.idx)
+				)
+			slabs = self._parse_slabs(row)
+			self._validate_pt_slabs(slabs, row.idx)
 
-    def _validate_locked_periods(self, table_fieldname, label, protected_fields):
-        """If a submitted Salary Structure Assignment exists for a period,
-        block edits to components and rate fields.
-        Note: to_date is intentionally excluded from protected_fields so it
-        remains editable even when the period is locked."""
-        old_doc = self.get_doc_before_save()
-        if not old_doc:
-            return  # new doc — nothing to compare
+	def _validate_pt_period_overlap(self, rows):
+		dated = []
+		for row in rows:
+			if not row.from_date and not row.to_date:
+				continue
+			start = getdate(row.from_date) if row.from_date else getdate("1900-01-01")
+			end = getdate(row.to_date) if row.to_date else getdate("9999-12-31")
+			if start > end:
+				frappe.throw(
+					_("Professional Tax period row {0}: From Date cannot be after To Date.").format(row.idx)
+				)
+			dated.append((start, end, row.idx))
 
-        old_rows = {
-            row.name: row
-            for row in (old_doc.get(table_fieldname) or [])
-            if row.name
-        }
+		for i, (a_start, a_end, a_idx) in enumerate(dated):
+			for b_start, b_end, b_idx in dated[i + 1:]:
+				if a_start <= b_end and b_start <= a_end:
+					frappe.throw(
+						_("Professional Tax periods overlap (rows {0} and {1}).").format(a_idx, b_idx)
+					)
 
-        for row in (self.get(table_fieldname) or []):
-            if not row.name or row.name not in old_rows:
-                continue  # newly added row — allowed
+	def _validate_pt_slabs(self, slabs, row_idx):
+		if not slabs:
+			return
+		by_gender = {"Male": [], "Female": []}
+		for i, slab in enumerate(slabs):
+			gender = slab.get("gender")
+			if gender not in ("Male", "Female"):
+				frappe.throw(
+					_("Professional Tax slab {0} in period row {1}: gender must be Male or Female.")
+					.format(i + 1, row_idx)
+				)
+			from_amount = flt(slab.get("from_amount"))
+			to_raw = slab.get("to_amount")
+			tax_amount = flt(slab.get("tax_amount"))
+			if from_amount < 0 or tax_amount < 0:
+				frappe.throw(
+					_("Professional Tax slab {0} in period row {1}: amounts cannot be negative.")
+					.format(i + 1, row_idx)
+				)
+			if to_raw is not None and to_raw != "":
+				to_amount = flt(to_raw)
+				if to_amount < 0:
+					frappe.throw(
+						_("Professional Tax slab {0} in period row {1}: To Amount cannot be negative.")
+						.format(i + 1, row_idx)
+					)
+				if to_amount < from_amount:
+					frappe.throw(
+						_("Professional Tax slab {0} in period row {1}: To Amount cannot be less than From.")
+						.format(i + 1, row_idx)
+					)
+			by_gender[gender].append(slab)
 
-            if not self._period_has_ssa(row.from_date, row.to_date):
-                continue  # no SSA for this period — editable
+		for gender, gender_slabs in by_gender.items():
+			if not gender_slabs:
+				continue
+			sorted_slabs = sorted(gender_slabs, key=lambda s: flt(s.get("from_amount")))
+			for i in range(len(sorted_slabs) - 1):
+				cur_to = sorted_slabs[i].get("to_amount")
+				nxt_from = flt(sorted_slabs[i + 1].get("from_amount"))
+				if cur_to is None or cur_to == "":
+					frappe.throw(
+						_("Professional Tax {0} slabs in period row {1}: open-ended slab must be last.")
+						.format(gender, row_idx)
+					)
+				if flt(cur_to) >= nxt_from:
+					frappe.throw(
+						_("Professional Tax {0} slabs overlap in period row {1}.").format(gender, row_idx)
+					)
 
-            old_row = old_rows[row.name]
-            for field in protected_fields:
-                old_val = str(old_row.get(field) or "")
-                new_val = str(row.get(field) or "")
-                # For floats compare numerically to avoid "0" vs "0.0" false positives
-                try:
-                    changed = flt(old_val) != flt(new_val)
-                except Exception:
-                    changed = old_val != new_val
+	# ──────────────────────────────────────────────
+	# Lock validation — SSA exists → cannot edit period
+	# ──────────────────────────────────────────────
 
-                if changed:
-                    period_str = "{0} → {1}".format(
-                        row.from_date or "open", row.to_date or "open"
-                    )
-                    frappe.throw(
-                        _("{0} period <b>{1}</b>: Cannot edit — "
-                          "Salary Structure Assignment already exists for this period.")
-                        .format(label, period_str)
-                    )
+	def _validate_locked_periods(self, table_fieldname, label, protected_fields):
+		"""If a submitted Salary Structure Assignment exists for a period,
+		block edits to components and rate fields.
+		Note: to_date is intentionally excluded from protected_fields so it
+		remains editable even when the period is locked."""
+		old_doc = self.get_doc_before_save()
+		if not old_doc:
+			return  # new doc — nothing to compare
 
-    def _period_has_ssa(self, from_date, to_date) -> bool:
-        """Return True if any submitted SSA's from_date falls within [from_date, to_date]."""
-        filters = {"company": self.name, "docstatus": 1}
-        if from_date and to_date:
-            filters["from_date"] = ["between", [from_date, to_date]]
-        elif from_date:
-            filters["from_date"] = [">=", from_date]
-        elif to_date:
-            filters["from_date"] = ["<=", to_date]
-        return bool(frappe.db.exists("Salary Structure Assignment", filters))
+		old_rows = {
+			row.name: row
+			for row in (old_doc.get(table_fieldname) or [])
+			if row.name
+		}
 
-    # ──────────────────────────────────────────────
-    # Helpers
-    # ──────────────────────────────────────────────
+		for row in (self.get(table_fieldname) or []):
+			if not row.name or row.name not in old_rows:
+				continue  # newly added row — allowed
 
-    def _parse_components(self, row) -> list:
-        raw = row.get("wage_components") if row else None
-        if not raw:
-            return []
-        try:
-            result = json.loads(raw)
-            return result if isinstance(result, list) else []
-        except (json.JSONDecodeError, TypeError, ValueError):
-            return []
+			if not self._period_has_ssa(row.from_date, row.to_date):
+				continue  # no SSA for this period — editable
 
-    def _get_matching_row(self, table_fieldname: str, period_date=None):
-        """Return first row whose date range covers period_date. None if no match."""
-        for row in (self.get(table_fieldname) or []):
-            if not period_date:
-                return row   # validate time — just return first
-            if not row.from_date and not row.to_date:
-                return row   # always active
-            from_ok = (not row.from_date) or (getdate(row.from_date) <= getdate(period_date))
-            to_ok   = (not row.to_date)   or (getdate(row.to_date)   >= getdate(period_date))
-            if from_ok and to_ok:
-                return row
-        return None
+			old_row = old_rows[row.name]
+			for field in protected_fields:
+				old_val = str(old_row.get(field) or "")
+				new_val = str(row.get(field) or "")
+				# Numeric compare only when both values are plain numbers (not JSON text)
+				try:
+					float(old_val)
+					float(new_val)
+					changed = flt(old_val) != flt(new_val)
+				except (TypeError, ValueError):
+					changed = old_val != new_val
 
-    def _validate_components(self, components: list, label_prefix: str):
-        for comp in components:
-            if comp in VIRTUAL_COMPONENTS:
-                continue
-            comp_type = frappe.db.get_value("Salary Component", comp, "type")
-            if not comp_type:
-                frappe.throw(_("{0} Wage Component <b>{1}</b> does not exist.").format(label_prefix, comp))
-            if comp_type != "Earning":
-                frappe.throw(_("{0} Wage Component <b>{1}</b> must be of type Earning.").format(label_prefix, comp))
+				if changed:
+					period_str = "{0} → {1}".format(
+						row.from_date or "open", row.to_date or "open"
+					)
+					frappe.throw(
+						_("{0} period <b>{1}</b>: Cannot edit — "
+						  "Salary Structure Assignment already exists for this period.")
+						.format(label, period_str)
+					)
 
-    def _resolve_component_value(self, comp: str, salary_components: dict) -> float:
-        if comp == "Gross":
-            if "Gross" in salary_components:
-                return float(salary_components["Gross"])
-            return float(sum(
-                v for k, v in salary_components.items()
-                if k not in VIRTUAL_COMPONENTS and not k.startswith("_")
-            ))
-        if comp == "Gross Including Additional Salary":
-            if "Gross Including Additional Salary" in salary_components:
-                return float(salary_components["Gross Including Additional Salary"])
-            gross = float(sum(
-                v for k, v in salary_components.items()
-                if k not in VIRTUAL_COMPONENTS and not k.startswith("_")
-            ))
-            return gross + float(salary_components.get("_additional_salary", 0.0))
-        return float(salary_components.get(comp, 0.0))
+	def _period_has_ssa(self, from_date, to_date) -> bool:
+		"""Return True if any submitted SSA's from_date falls within [from_date, to_date]."""
+		filters = {"company": self.name, "docstatus": 1}
+		if from_date and to_date:
+			filters["from_date"] = ["between", [from_date, to_date]]
+		elif from_date:
+			filters["from_date"] = [">=", from_date]
+		elif to_date:
+			filters["from_date"] = ["<=", to_date]
+		return bool(frappe.db.exists("Salary Structure Assignment", filters))
 
-    # ──────────────────────────────────────────────
-    # Wage basis calculators
-    # ──────────────────────────────────────────────
+	# ──────────────────────────────────────────────
+	# Helpers
+	# ──────────────────────────────────────────────
 
-    def compute_esic_wage_basis(self, salary_components: dict, period_date=None) -> float:
-        row = self._get_matching_row("esic_dependent_component", period_date)
-        if not row:
-            return 0.0
-        components = self._parse_components(row)
-        if not components:
-            return 0.0
-        return max(sum(self._resolve_component_value(c, salary_components) for c in components), 0.0)
+	def _parse_components(self, row) -> list:
+		raw = row.get("wage_components") if row else None
+		if not raw:
+			return []
+		try:
+			result = json.loads(raw)
+			return result if isinstance(result, list) else []
+		except (json.JSONDecodeError, TypeError, ValueError):
+			return []
 
-    def compute_pf_wage_basis(self, salary_components: dict, period_date=None) -> float:
-        row = self._get_matching_row("pf_dependent_component", period_date)
-        if not row:
-            return 0.0
-        components = self._parse_components(row)
-        if not components:
-            return 0.0
-        return max(sum(self._resolve_component_value(c, salary_components) for c in components), 0.0)
+	def _parse_slabs(self, row) -> list:
+		raw = row.get("slabs") if row else None
+		if not raw:
+			return []
+		try:
+			result = json.loads(raw)
+			return result if isinstance(result, list) else []
+		except (json.JSONDecodeError, TypeError, ValueError):
+			return []
 
-    # ──────────────────────────────────────────────
-    # Public config helpers
-    # ──────────────────────────────────────────────
+	def _get_matching_row(self, table_fieldname: str, period_date=None):
+		"""Return first row whose date range covers period_date. None if no match."""
+		for row in (self.get(table_fieldname) or []):
+			if not period_date:
+				return row   # validate time — just return first
+			if not row.from_date and not row.to_date:
+				return row   # always active
+			from_ok = (not row.from_date) or (getdate(row.from_date) <= getdate(period_date))
+			to_ok   = (not row.to_date)   or (getdate(row.to_date)   >= getdate(period_date))
+			if from_ok and to_ok:
+				return row
+		return None
 
-    def get_salary_calculation_method(self) -> str:
-        return "Include Weekly Offs" if "Include" in (self.salary_calculation_based_on or "") else "Exclude Weekly Offs"
+	def _validate_components(self, components: list, label_prefix: str):
+		for comp in components:
+			if comp in VIRTUAL_COMPONENTS:
+				continue
+			comp_type = frappe.db.get_value("Salary Component", comp, "type")
+			if not comp_type:
+				frappe.throw(_("{0} Wage Component <b>{1}</b> does not exist.").format(label_prefix, comp))
+			if comp_type != "Earning":
+				frappe.throw(_("{0} Wage Component <b>{1}</b> must be of type Earning.").format(label_prefix, comp))
 
-    def get_esic_config(self, period_date=None):
-        row = self._get_matching_row("esic_dependent_component", period_date)
-        if not row:
-            return None
-        components = self._parse_components(row)
-        if not components:
-            return None
-        return {
-            "is_applicable":    True,
-            "wage_components":  components,
-            "wage_limit":       flt(row.esic_wage_limit) or None,
-            "employee_percent": flt(row.employee_contribution) or 0,
-            "employer_percent": flt(row.employer_contribution) or 0,
-        }
+	def _resolve_component_value(self, comp: str, salary_components: dict) -> float:
+		if comp == "Gross":
+			if "Gross" in salary_components:
+				return float(salary_components["Gross"])
+			return float(sum(
+				v for k, v in salary_components.items()
+				if k not in VIRTUAL_COMPONENTS and not k.startswith("_")
+			))
+		if comp == "Gross Including Additional Salary":
+			if "Gross Including Additional Salary" in salary_components:
+				return float(salary_components["Gross Including Additional Salary"])
+			gross = float(sum(
+				v for k, v in salary_components.items()
+				if k not in VIRTUAL_COMPONENTS and not k.startswith("_")
+			))
+			return gross + float(salary_components.get("_additional_salary", 0.0))
+		return float(salary_components.get(comp, 0.0))
 
-    def get_pf_config(self, period_date=None):
-        row = self._get_matching_row("pf_dependent_component", period_date)
-        if not row:
-            return None
-        components = self._parse_components(row)
-        if not components:
-            return None
-        return {
-            "is_applicable":    True,
-            "wage_components":  components,
-            "wage_limit":       flt(row.pf_wage_limit) or None,
-            "employee_percent": flt(row.employee_percent) or 0,
-            "employer_eps":     flt(row.employer_eps) or 0,
-            "employer_epf":     flt(row.employer_epf) or 0,
-            "edli_insurance":   flt(row.edli_insurance) or 0,
-            "admin_charges":    flt(row.admin_charges) or 0,
-        }
+	# ──────────────────────────────────────────────
+	# Wage basis calculators
+	# ──────────────────────────────────────────────
+
+	def compute_esic_wage_basis(self, salary_components: dict, period_date=None) -> float:
+		row = self._get_matching_row("esic_dependent_component", period_date)
+		if not row:
+			return 0.0
+		components = self._parse_components(row)
+		if not components:
+			return 0.0
+		return max(sum(self._resolve_component_value(c, salary_components) for c in components), 0.0)
+
+	def compute_pf_wage_basis(self, salary_components: dict, period_date=None) -> float:
+		row = self._get_matching_row("pf_dependent_component", period_date)
+		if not row:
+			return 0.0
+		components = self._parse_components(row)
+		if not components:
+			return 0.0
+		return max(sum(self._resolve_component_value(c, salary_components) for c in components), 0.0)
+
+	# ──────────────────────────────────────────────
+	# Public config helpers
+	# ──────────────────────────────────────────────
+
+	def get_salary_calculation_method(self) -> str:
+		return "Include Weekly Offs" if "Include" in (self.salary_calculation_based_on or "") else "Exclude Weekly Offs"
+
+	def get_esic_config(self, period_date=None):
+		row = self._get_matching_row("esic_dependent_component", period_date)
+		if not row:
+			return None
+		components = self._parse_components(row)
+		if not components:
+			return None
+		return {
+			"is_applicable":    True,
+			"wage_components":  components,
+			"wage_limit":       flt(row.esic_wage_limit) or None,
+			"employee_percent": flt(row.employee_contribution) or 0,
+			"employer_percent": flt(row.employer_contribution) or 0,
+		}
+
+	def get_pf_config(self, period_date=None):
+		row = self._get_matching_row("pf_dependent_component", period_date)
+		if not row:
+			return None
+		components = self._parse_components(row)
+		if not components:
+			return None
+		return {
+			"is_applicable":    True,
+			"wage_components":  components,
+			"wage_limit":       flt(row.pf_wage_limit) or None,
+			"employee_percent": flt(row.employee_percent) or 0,
+			"employer_eps":     flt(row.employer_eps) or 0,
+			"employer_epf":     flt(row.employer_epf) or 0,
+			"edli_insurance":   flt(row.edli_insurance) or 0,
+			"admin_charges":    flt(row.admin_charges) or 0,
+		}
+
+	def get_pt_config(self, period_date=None):
+		row = self._get_matching_row("pt_periods", period_date)
+		if not row:
+			return None
+		return {
+			"february_amount": flt(row.february_amount) if row.february_amount is not None else DEFAULT_PT_FEBRUARY_AMOUNT,
+			"age_exempt_years": cint(row.age_exempt_years) if row.age_exempt_years is not None else DEFAULT_PT_AGE_EXEMPT_YEARS,
+			"slabs": self._parse_slabs(row),
+			"from_date": row.from_date,
+			"to_date": row.to_date,
+		}
+
+	def calculate_pt(self, gross, gender, period_date, date_of_birth=None) -> float:
+		"""Return monthly Professional Tax from company slabs for gross/gender/date."""
+		cfg = self.get_pt_config(period_date)
+		if not cfg:
+			return 0.0
+
+		if date_of_birth and period_date:
+			from dateutil.relativedelta import relativedelta
+			age = relativedelta(getdate(period_date), getdate(date_of_birth)).years
+			if age >= cint(cfg.get("age_exempt_years") or DEFAULT_PT_AGE_EXEMPT_YEARS):
+				return 0.0
+
+		resolved_gender = gender if gender in ("Male", "Female") else "Male"
+		gross_amt = flt(gross)
+		tax = 0.0
+		matched = False
+		for slab in cfg.get("slabs") or []:
+			if slab.get("gender") != resolved_gender:
+				continue
+			from_amount = flt(slab.get("from_amount"))
+			to_raw = slab.get("to_amount")
+			in_range = gross_amt >= from_amount and (
+				to_raw is None or to_raw == "" or gross_amt <= flt(to_raw)
+			)
+			if in_range:
+				tax = flt(slab.get("tax_amount"))
+				matched = True
+				break
+
+		if not matched:
+			return 0.0
+
+		if period_date and getdate(period_date).month == 2 and tax > 0:
+			return flt(cfg.get("february_amount"))
+		return tax

--- a/saral_hr/saral_hr/doctype/company/test_company.py
+++ b/saral_hr/saral_hr/doctype/company/test_company.py
@@ -174,7 +174,7 @@ class TestCompanyEmployeeCounts(FrappeTestCase):
 
 
 class TestCompanyProfessionalTax(FrappeTestCase):
-	def _make_pt_company(self, slabs=None, february_amount=300, age_exempt_years=65):
+	def _make_pt_company(self, slabs=None, age_exempt_years=65):
 		from saral_hr.saral_hr.doctype.company.company import maharashtra_pt_slabs_json
 		import json
 
@@ -191,7 +191,6 @@ class TestCompanyProfessionalTax(FrappeTestCase):
 					{
 						"from_date": None,
 						"to_date": None,
-						"february_amount": february_amount,
 						"age_exempt_years": age_exempt_years,
 						"slabs": json.dumps(slabs) if slabs is not None else maharashtra_pt_slabs_json(),
 					}
@@ -215,12 +214,52 @@ class TestCompanyProfessionalTax(FrappeTestCase):
 		self.assertEqual(comp.calculate_pt(25000, "Female", "2026-01-15"), 0.0)
 		self.assertEqual(comp.calculate_pt(25001, "Female", "2026-01-15"), 200.0)
 
-	def test_february_override_only_when_tax_positive(self):
-		comp = self._make_pt_company(february_amount=300)
+	def test_february_male_mid_and_top_slabs(self):
+		comp = self._make_pt_company()
 		self.assertEqual(comp.calculate_pt(5000, "Male", "2026-02-10"), 0.0)
+		self.assertEqual(comp.calculate_pt(8000, "Male", "2026-02-10"), 275.0)
 		self.assertEqual(comp.calculate_pt(12000, "Male", "2026-02-10"), 300.0)
-		self.assertEqual(comp.calculate_pt(30000, "Female", "2026-02-10"), 300.0)
+		self.assertEqual(comp.calculate_pt(8000, "Male", "2026-01-10"), 175.0)
 		self.assertEqual(comp.calculate_pt(12000, "Male", "2026-01-10"), 200.0)
+
+	def test_february_female_stays_at_tax_amount(self):
+		comp = self._make_pt_company()
+		self.assertEqual(comp.calculate_pt(30000, "Female", "2026-02-10"), 200.0)
+		self.assertEqual(comp.calculate_pt(30000, "Female", "2026-01-10"), 200.0)
+		self.assertEqual(comp.calculate_pt(20000, "Female", "2026-02-10"), 0.0)
+
+	def test_february_amount_on_zero_tax_slab_rejected(self):
+		import json
+
+		uid = _uid()
+		doc = frappe.get_doc(
+			{
+				"doctype": "Company",
+				"company": f"_Test Co PT BadFeb {uid}",
+				"abbr": f"B{uid}"[:8],
+				"country": "India",
+				"default_currency": "INR",
+				"salary_calculation_based_on": "Exclude Weekly Offs (Working Days)",
+				"pt_periods": [
+					{
+						"age_exempt_years": 65,
+						"slabs": json.dumps(
+							[
+								{
+									"gender": "Male",
+									"from_amount": 0,
+									"to_amount": 7500,
+									"tax_amount": 0,
+									"february_amount": 300,
+								}
+							]
+						),
+					}
+				],
+			}
+		)
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert(ignore_permissions=True)
 
 	def test_age_exemption(self):
 		comp = self._make_pt_company(age_exempt_years=65)
@@ -269,14 +308,12 @@ class TestCompanyProfessionalTax(FrappeTestCase):
 					{
 						"from_date": "2026-01-01",
 						"to_date": "2026-06-30",
-						"february_amount": 300,
 						"age_exempt_years": 65,
 						"slabs": maharashtra_pt_slabs_json(),
 					},
 					{
 						"from_date": "2026-06-01",
 						"to_date": "2026-12-31",
-						"february_amount": 300,
 						"age_exempt_years": 65,
 						"slabs": maharashtra_pt_slabs_json(),
 					},

--- a/saral_hr/saral_hr/doctype/company/test_company.py
+++ b/saral_hr/saral_hr/doctype/company/test_company.py
@@ -171,3 +171,117 @@ class TestCompanyEmployeeCounts(FrappeTestCase):
 	def test_helper_noop_for_missing_company(self):
 		update_company_employee_counts(None)
 		update_company_employee_counts("_Does Not Exist Counts Co")
+
+
+class TestCompanyProfessionalTax(FrappeTestCase):
+	def _make_pt_company(self, slabs=None, february_amount=300, age_exempt_years=65):
+		from saral_hr.saral_hr.doctype.company.company import maharashtra_pt_slabs_json
+		import json
+
+		uid = _uid()
+		doc = frappe.get_doc(
+			{
+				"doctype": "Company",
+				"company": f"_Test Co PT {uid}",
+				"abbr": f"P{uid}"[:8],
+				"country": "India",
+				"default_currency": "INR",
+				"salary_calculation_based_on": "Exclude Weekly Offs (Working Days)",
+				"pt_periods": [
+					{
+						"from_date": None,
+						"to_date": None,
+						"february_amount": february_amount,
+						"age_exempt_years": age_exempt_years,
+						"slabs": json.dumps(slabs) if slabs is not None else maharashtra_pt_slabs_json(),
+					}
+				],
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		return doc
+
+	def test_male_slab_boundaries(self):
+		comp = self._make_pt_company()
+		self.assertEqual(comp.calculate_pt(0, "Male", "2026-01-15"), 0.0)
+		self.assertEqual(comp.calculate_pt(7500, "Male", "2026-01-15"), 0.0)
+		self.assertEqual(comp.calculate_pt(7501, "Male", "2026-01-15"), 175.0)
+		self.assertEqual(comp.calculate_pt(10000, "Male", "2026-01-15"), 175.0)
+		self.assertEqual(comp.calculate_pt(10001, "Male", "2026-01-15"), 200.0)
+		self.assertEqual(comp.calculate_pt(50000, "Male", "2026-01-15"), 200.0)
+
+	def test_female_slab_boundaries(self):
+		comp = self._make_pt_company()
+		self.assertEqual(comp.calculate_pt(25000, "Female", "2026-01-15"), 0.0)
+		self.assertEqual(comp.calculate_pt(25001, "Female", "2026-01-15"), 200.0)
+
+	def test_february_override_only_when_tax_positive(self):
+		comp = self._make_pt_company(february_amount=300)
+		self.assertEqual(comp.calculate_pt(5000, "Male", "2026-02-10"), 0.0)
+		self.assertEqual(comp.calculate_pt(12000, "Male", "2026-02-10"), 300.0)
+		self.assertEqual(comp.calculate_pt(30000, "Female", "2026-02-10"), 300.0)
+		self.assertEqual(comp.calculate_pt(12000, "Male", "2026-01-10"), 200.0)
+
+	def test_age_exemption(self):
+		comp = self._make_pt_company(age_exempt_years=65)
+		self.assertEqual(
+			comp.calculate_pt(50000, "Male", "2026-01-15", date_of_birth="1960-01-01"),
+			0.0,
+		)
+		self.assertEqual(
+			comp.calculate_pt(50000, "Male", "2026-01-15", date_of_birth="1990-01-01"),
+			200.0,
+		)
+
+	def test_missing_or_other_gender_uses_male_slabs(self):
+		comp = self._make_pt_company()
+		self.assertEqual(comp.calculate_pt(8000, None, "2026-01-15"), 175.0)
+		self.assertEqual(comp.calculate_pt(8000, "Other", "2026-01-15"), 175.0)
+		self.assertEqual(comp.calculate_pt(8000, "", "2026-01-15"), 175.0)
+
+	def test_no_period_returns_zero(self):
+		uid = _uid()
+		comp = frappe.get_doc(
+			{
+				"doctype": "Company",
+				"company": f"_Test Co PT Empty {uid}",
+				"abbr": f"E{uid}"[:8],
+				"country": "India",
+				"default_currency": "INR",
+				"salary_calculation_based_on": "Exclude Weekly Offs (Working Days)",
+			}
+		).insert(ignore_permissions=True)
+		self.assertEqual(comp.calculate_pt(50000, "Male", "2026-01-15"), 0.0)
+
+	def test_overlapping_periods_rejected(self):
+		from saral_hr.saral_hr.doctype.company.company import maharashtra_pt_slabs_json
+
+		uid = _uid()
+		doc = frappe.get_doc(
+			{
+				"doctype": "Company",
+				"company": f"_Test Co PT Overlap {uid}",
+				"abbr": f"O{uid}"[:8],
+				"country": "India",
+				"default_currency": "INR",
+				"salary_calculation_based_on": "Exclude Weekly Offs (Working Days)",
+				"pt_periods": [
+					{
+						"from_date": "2026-01-01",
+						"to_date": "2026-06-30",
+						"february_amount": 300,
+						"age_exempt_years": 65,
+						"slabs": maharashtra_pt_slabs_json(),
+					},
+					{
+						"from_date": "2026-06-01",
+						"to_date": "2026-12-31",
+						"february_amount": 300,
+						"age_exempt_years": 65,
+						"slabs": maharashtra_pt_slabs_json(),
+					},
+				],
+			}
+		)
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert(ignore_permissions=True)

--- a/saral_hr/saral_hr/doctype/ctc_calculator_record/ctc_calculator_record.py
+++ b/saral_hr/saral_hr/doctype/ctc_calculator_record/ctc_calculator_record.py
@@ -17,8 +17,6 @@ def _round0(value):
 
 GRATUITY_RATE  = 4.81 / 100
 RETENTION_RATE = 2.00 / 100   # Basic+DA × 2%
-PT_NORMAL      = 200.0
-PT_FEBRUARY    = 300.0
 
 STATUTORY_NAMES = {
     "Employee ESIC", "Employer ESIC",
@@ -53,6 +51,47 @@ DEDUCTION_FORMULAS = {
 }
 
 REMAINDER_KEYWORDS = ["other allowance", "others", "other", "oa", "remainder", "balance"]
+
+_MONTH_TO_NUM = {
+    "January": 1, "February": 2, "March": 3, "April": 4,
+    "May": 5, "June": 6, "July": 7, "August": 8,
+    "September": 9, "October": 10, "November": 11, "December": 12,
+}
+
+
+def _company_pt_amount(company, gross, month_name, gender="Male"):
+    if not company:
+        return 0.0
+    try:
+        from datetime import date
+        from frappe.utils import getdate
+        comp = frappe.get_doc("Company", company)
+        month_num = _MONTH_TO_NUM.get(month_name or "January", 1)
+        period_date = date(date.today().year, month_num, 1)
+        return flt(comp.calculate_pt(gross, gender, period_date, None))
+    except Exception:
+        return 0.0
+
+REMAINDER_KEYWORDS = ["other allowance", "others", "other", "oa", "remainder", "balance"]
+
+_MONTH_TO_NUM = {
+    "January": 1, "February": 2, "March": 3, "April": 4,
+    "May": 5, "June": 6, "July": 7, "August": 8,
+    "September": 9, "October": 10, "November": 11, "December": 12,
+}
+
+
+def _company_pt_amount(company, gross, month_name, gender="Male"):
+    if not company:
+        return 0.0
+    try:
+        from datetime import date
+        comp = frappe.get_doc("Company", company)
+        month_num = _MONTH_TO_NUM.get(month_name or "January", 1)
+        period_date = date(date.today().year, month_num, 1)
+        return flt(comp.calculate_pt(gross, gender, period_date, None))
+    except Exception:
+        return 0.0
 
 
 @frappe.whitelist()
@@ -215,7 +254,6 @@ def calculate_ctc_breakdown(company, salary_structure, annual_ctc, month=None,
     annual_ctc  = flt(annual_ctc)
     monthly_ctc = _round2(annual_ctc / 12)
     month_name  = month or "January"
-    is_february = (month_name == "February")
 
     company_stat = _get_company_statutory(company)
 
@@ -294,7 +332,7 @@ def calculate_ctc_breakdown(company, salary_structure, annual_ctc, month=None,
 
     emp_pf       = _round2(pf_wage * pf_emp_pct)             if is_pf   else 0.0
     esic_emp_amt = _round2(total_gross * esic_emp_pct / 100) if is_esic else 0.0
-    pt_amount    = (PT_FEBRUARY if is_february else PT_NORMAL) if is_pt  else 0.0
+    pt_amount    = _company_pt_amount(company, total_gross, month_name) if is_pt else 0.0
 
     # ✅ Retention — only if checkbox checked, using same RETENTION_RATE formula
     retention_amt = _round2(basic_da * RETENTION_RATE) if is_retention else 0.0

--- a/saral_hr/saral_hr/doctype/professional_tax_period/professional_tax_period.json
+++ b/saral_hr/saral_hr/doctype/professional_tax_period/professional_tax_period.json
@@ -1,0 +1,61 @@
+{
+ "actions": [],
+ "creation": "2026-08-04 10:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "from_date",
+  "to_date",
+  "february_amount",
+  "age_exempt_years",
+  "slabs"
+ ],
+ "fields": [
+  {
+   "fieldname": "from_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "From Date"
+  },
+  {
+   "fieldname": "to_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "To Date"
+  },
+  {
+   "default": "300",
+   "fieldname": "february_amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "February Amount",
+   "precision": "2"
+  },
+  {
+   "default": "65",
+   "fieldname": "age_exempt_years",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Age Exempt Years",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "slabs",
+   "fieldtype": "Small Text",
+   "label": "Slabs (JSON)"
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-08-04 10:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Saral Hr",
+ "name": "Professional Tax Period",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/saral_hr/saral_hr/doctype/professional_tax_period/professional_tax_period.json
+++ b/saral_hr/saral_hr/doctype/professional_tax_period/professional_tax_period.json
@@ -7,7 +7,6 @@
  "field_order": [
   "from_date",
   "to_date",
-  "february_amount",
   "age_exempt_years",
   "slabs"
  ],
@@ -23,14 +22,6 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "To Date"
-  },
-  {
-   "default": "300",
-   "fieldname": "february_amount",
-   "fieldtype": "Currency",
-   "in_list_view": 1,
-   "label": "February Amount",
-   "precision": "2"
   },
   {
    "default": "65",
@@ -49,7 +40,7 @@
  "index_web_pages_for_search": 0,
  "istable": 1,
  "links": [],
- "modified": "2026-08-04 10:00:00.000000",
+ "modified": "2026-08-04 10:30:00.000000",
  "modified_by": "Administrator",
  "module": "Saral Hr",
  "name": "Professional Tax Period",

--- a/saral_hr/saral_hr/doctype/professional_tax_period/professional_tax_period.py
+++ b/saral_hr/saral_hr/doctype/professional_tax_period/professional_tax_period.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, sj and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class ProfessionalTaxPeriod(Document):
+	pass

--- a/saral_hr/saral_hr/doctype/salary_slip/salary_slip.py
+++ b/saral_hr/saral_hr/doctype/salary_slip/salary_slip.py
@@ -36,6 +36,46 @@ def _company_for_employee(employee):
     return frappe.db.get_value("Company Link", employee, "company")
 
 
+def _employee_gender_dob(employee):
+    """Resolve gender and DOB from Employee / Company Link."""
+    gender = None
+    dob = None
+    if not employee:
+        return gender, dob
+    if frappe.db.exists("Employee", employee):
+        row = frappe.db.get_value("Employee", employee, ["gender", "date_of_birth"], as_dict=True)
+        if row:
+            gender, dob = row.gender, row.date_of_birth
+    if not dob or not gender:
+        link = frappe.db.get_value(
+            "Company Link", employee, ["employee", "date_of_birth", "gender"], as_dict=True
+        )
+        if link:
+            dob = dob or link.date_of_birth
+            gender = gender or getattr(link, "gender", None)
+            if link.employee and (not dob or not gender):
+                emp = frappe.db.get_value(
+                    "Employee", link.employee, ["gender", "date_of_birth"], as_dict=True
+                )
+                if emp:
+                    gender = gender or emp.gender
+                    dob = dob or emp.date_of_birth
+    return gender, dob
+
+
+def _company_pt_amount(company, gross, employee, period_date):
+    if not company or not period_date:
+        return 0.0
+    try:
+        comp_doc = frappe.get_doc("Company", company)
+    except frappe.DoesNotExistError:
+        return 0.0
+    if not hasattr(comp_doc, "calculate_pt"):
+        return 0.0
+    gender, dob = _employee_gender_dob(employee)
+    return flt(comp_doc.calculate_pt(gross, gender, period_date, dob))
+
+
 def round_salary_amount(value, company=None, digits=None):
     if digits is None:
         digits = get_salary_amount_rounding_digits(company)
@@ -317,14 +357,17 @@ def get_salary_structure_for_employee(
     for row in (ssa_doc.deductions or []):
         if statutory_needs_recompute and _is_statutory_component(row.salary_component):
             continue
-        if _is_pt_component(row.salary_component) and _is_pt_exempt(employee, start_date):
-            continue
         meta          = _comp_meta(row.salary_component)
         is_daily_wage = int(meta.get("daily_wage_component") or getattr(row, "daily_wage_component", 0) or 0)
         per_day_rate  = flt(getattr(row, "per_day_rate", None) or 0)
         amount        = flt(row.amount, amount_digits)
         if _is_pt_component(row.salary_component):
-            amount = 300.0 if current_month == "February" else 200.0
+            # Preview only — final PT is applied after gross in calculate_salary_slip_amounts_exact
+            ssa_gross_est = sum(flt(r.amount) for r in (ssa_doc.earnings or []))
+            amount = flt(
+                _company_pt_amount(ssa_doc.company, ssa_gross_est, employee, start_date),
+                amount_digits,
+            )
         deductions.append({
             "salary_component":                 row.salary_component,
             "abbr":                             meta.get("salary_component_abbr") or getattr(row, "abbr", "") or "",
@@ -370,13 +413,10 @@ def get_salary_structure_for_employee(
             pf_type=ssa_doc.pf_applicable or "",
             is_pt_applicable=int(ssa_doc.is_pt_applicable or 0),
             is_lwf_applicable=int(ssa_doc.is_lwf_applicable or 0),
+            employee=employee,
         )
         for d in (recomputed.get("deductions") or []):
-            if _is_pt_component(d["salary_component"]) and _is_pt_exempt(employee, start_date):
-                continue
             amount = flt(d["amount"], amount_digits)
-            if _is_pt_component(d["salary_component"]):
-                amount = 300.0 if current_month == "February" else 200.0
             deductions.append({
                 "salary_component": d["salary_component"], "abbr": d.get("abbr") or "",
                 "amount": amount, "base_amount": amount,
@@ -416,28 +456,6 @@ def _is_statutory_component(comp_name):
 
 def _is_pt_component(comp_name):
     return (comp_name or "").strip() == PT_COMPONENT_NAME
-
-
-def _is_pt_exempt(employee, start_date):
-    if not employee or not start_date:
-        return False
-    try:
-        dob = frappe.db.get_value("Employee", employee, "date_of_birth")
-        if not dob:
-            dob = (
-                frappe.db.get_value("Company Link", employee, "date_of_birth") or
-                frappe.db.get_value(
-                    "Employee",
-                    frappe.db.get_value("Company Link", employee, "employee"),
-                    "date_of_birth"
-                )
-            )
-        if not dob:
-            return False
-        from dateutil.relativedelta import relativedelta
-        return relativedelta(getdate(start_date), getdate(dob)).years >= 65
-    except Exception:
-        return False
 
 
 def calculate_salary_slip_amounts_exact(
@@ -496,12 +514,8 @@ def calculate_salary_slip_amounts_exact(
         per_day_rate  = flt(getattr(row, "per_day_rate", 0) or 0)
         is_pt         = _is_pt_component(row.salary_component)
 
-        if is_pt and _is_pt_exempt(salary_slip.employee, start_date):
-            row.amount = 0.0
-            continue
-
         if is_pt:
-            amount = 300.0 if start_month == 2 else 200.0
+            amount = _company_pt_amount(company, total_earnings, salary_slip.employee, start_date)
         elif _is_statutory_component(row.salary_component):
             amount = base
         elif is_daily_wage and per_day_rate > 0:
@@ -569,7 +583,7 @@ SC_EMPR_LWF   = "Employer Labour Welfare Fund"
 def get_statutory_components_internal(
     company, gross_salary, earnings_map, from_date,
     is_esic_applicable, is_pf_applicable, pf_type,
-    is_pt_applicable, is_lwf_applicable
+    is_pt_applicable, is_lwf_applicable, employee=None
 ):
     VIRTUAL = {"Gross", "Gross Including Additional Salary"}
 
@@ -616,8 +630,10 @@ def get_statutory_components_internal(
             if edli: employer_share.append(row(SC_EMPR_EDLI,  wage * edli / 100, emp=1))
             if adm:  employer_share.append(row(SC_EMPR_PFADM, wage * adm  / 100, emp=1))
 
-    if is_pt_applicable and month_name:
-        deductions.append(row(SC_PT, _sa_local(SC_PT, month_name)))
+    if is_pt_applicable and from_date and comp_doc:
+        gender, dob = _employee_gender_dob(employee)
+        pt_amt = flt(comp_doc.calculate_pt(gross_salary, gender, from_date, dob))
+        deductions.append(row(SC_PT, pt_amt))
 
     if is_lwf_applicable and month_name:
         deductions.append(row(SC_EMP_LWF, _sa_local(SC_EMP_LWF, month_name)))

--- a/saral_hr/saral_hr/doctype/salary_slip/test_professional_tax.py
+++ b/saral_hr/saral_hr/doctype/salary_slip/test_professional_tax.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, sj and Contributors
+# See license.txt
+
+"""Salary slip / SSA PT calculation uses Company slabs — no flat 200/300."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import getdate
+
+from saral_hr.saral_hr.doctype.company.company import maharashtra_pt_slabs_json
+from saral_hr.saral_hr.doctype.salary_slip.salary_slip import (
+	_company_pt_amount,
+	get_statutory_components_internal,
+)
+from saral_hr.saral_hr.doctype.salary_structure_assignment.salary_structure_assignment import (
+	get_statutory_components,
+)
+
+
+def _uid() -> str:
+	return frappe.generate_hash(length=6)
+
+
+def _make_pt_company() -> str:
+	uid = _uid()
+	doc = frappe.get_doc(
+		{
+			"doctype": "Company",
+			"company": f"_Test Co Slip PT {uid}",
+			"abbr": f"S{uid}"[:8],
+			"country": "India",
+			"default_currency": "INR",
+			"salary_calculation_based_on": "Exclude Weekly Offs (Working Days)",
+			"pt_periods": [
+				{
+					"from_date": None,
+					"to_date": None,
+					"february_amount": 300,
+					"age_exempt_years": 65,
+					"slabs": maharashtra_pt_slabs_json(),
+				}
+			],
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_employee(gender="Male", dob="1990-01-01") -> str:
+	doc = frappe.get_doc(
+		{
+			"doctype": "Employee",
+			"naming_series": "HR-EMP-",
+			"first_name": f"PTEmp{_uid()}",
+			"gender": gender,
+			"date_of_birth": dob,
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+class TestProfessionalTaxCalculationPaths(FrappeTestCase):
+	def test_company_pt_amount_helper(self):
+		company = _make_pt_company()
+		employee = _make_employee("Male")
+		self.assertEqual(_company_pt_amount(company, 12000, employee, "2026-01-15"), 200.0)
+		self.assertEqual(_company_pt_amount(company, 12000, employee, "2026-02-15"), 300.0)
+
+	def test_ssa_statutory_uses_slabs_not_flat(self):
+		company = _make_pt_company()
+		employee = _make_employee("Female")
+		result = get_statutory_components(
+			company=company,
+			gross_salary=30000,
+			from_date="2026-01-15",
+			is_pt_applicable=1,
+			employee=employee,
+		)
+		pt_rows = [d for d in result["deductions"] if d["salary_component"] == "Professional Tax"]
+		self.assertEqual(len(pt_rows), 1)
+		self.assertEqual(pt_rows[0]["amount"], 200.0)
+
+	def test_ssa_pt_off_returns_no_pt_row(self):
+		company = _make_pt_company()
+		employee = _make_employee("Male")
+		result = get_statutory_components(
+			company=company,
+			gross_salary=50000,
+			from_date="2026-01-15",
+			is_pt_applicable=0,
+			employee=employee,
+		)
+		pt_rows = [d for d in result["deductions"] if d["salary_component"] == "Professional Tax"]
+		self.assertEqual(pt_rows, [])
+
+	def test_slip_internal_uses_slabs(self):
+		company = _make_pt_company()
+		employee = _make_employee("Male")
+		result = get_statutory_components_internal(
+			company=company,
+			gross_salary=8000,
+			earnings_map={},
+			from_date="2026-01-15",
+			is_esic_applicable=0,
+			is_pf_applicable=0,
+			pf_type="",
+			is_pt_applicable=1,
+			is_lwf_applicable=0,
+			employee=employee,
+		)
+		pt_rows = [d for d in result["deductions"] if d["salary_component"] == "Professional Tax"]
+		self.assertEqual(len(pt_rows), 1)
+		self.assertEqual(pt_rows[0]["amount"], 175.0)
+
+	def test_no_hardcoded_pt_constants_in_ctc_modules(self):
+		import inspect
+		from saral_hr.saral_hr.page.ctc_calculator import ctc_calculator
+		from saral_hr.saral_hr.doctype.ctc_calculator_record import ctc_calculator_record
+
+		for mod in (ctc_calculator, ctc_calculator_record):
+			src = inspect.getsource(mod)
+			self.assertNotIn("PT_NORMAL", src)
+			self.assertNotIn("PT_FEBRUARY", src)

--- a/saral_hr/saral_hr/doctype/salary_slip/test_professional_tax.py
+++ b/saral_hr/saral_hr/doctype/salary_slip/test_professional_tax.py
@@ -35,7 +35,6 @@ def _make_pt_company() -> str:
 				{
 					"from_date": None,
 					"to_date": None,
-					"february_amount": 300,
 					"age_exempt_years": 65,
 					"slabs": maharashtra_pt_slabs_json(),
 				}
@@ -66,6 +65,12 @@ class TestProfessionalTaxCalculationPaths(FrappeTestCase):
 		employee = _make_employee("Male")
 		self.assertEqual(_company_pt_amount(company, 12000, employee, "2026-01-15"), 200.0)
 		self.assertEqual(_company_pt_amount(company, 12000, employee, "2026-02-15"), 300.0)
+		self.assertEqual(_company_pt_amount(company, 8000, employee, "2026-02-15"), 275.0)
+
+	def test_female_february_no_surcharge(self):
+		company = _make_pt_company()
+		employee = _make_employee("Female")
+		self.assertEqual(_company_pt_amount(company, 30000, employee, "2026-02-15"), 200.0)
 
 	def test_ssa_statutory_uses_slabs_not_flat(self):
 		company = _make_pt_company()

--- a/saral_hr/saral_hr/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/saral_hr/saral_hr/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -877,6 +877,7 @@ function refresh_statutory_rows(frm) {
             pf_type:            frm.doc.pf_applicable       || "",
             is_pt_applicable:   frm.doc.is_pt_applicable   ? 1 : 0,
             is_lwf_applicable:  frm.doc.is_lwf_applicable  ? 1 : 0,
+            employee:           frm.doc.employee           || "",
         },
         callback(r) {
             _statutory_inflight = false;

--- a/saral_hr/saral_hr/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/saral_hr/saral_hr/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -76,7 +76,7 @@ def get_statutory_components(company, gross_salary, from_date,
                               is_esic_applicable=0, is_pf_applicable=0,
                               pf_type=None, is_pt_applicable=0,
                               is_lwf_applicable=0,
-                              earnings_map=None):
+                              earnings_map=None, employee=None):
     import json as _json
 
     gross_salary       = flt(gross_salary)
@@ -150,10 +150,10 @@ def get_statutory_components(company, gross_salary, from_date,
             if adm_pct:
                 employer_share.append(row(SC_EMPR_PFADM, wage * adm_pct  / 100, employer=1))
 
-    # ── PT ──
-    if is_pt_applicable and from_date:
-        month_name = MONTHS[getdate(from_date).month - 1]
-        pt_amt     = _special_component_amount(SC_PT, month_name)
+    # ── PT (preview from SSA gross + employee gender/DOB) ──
+    if is_pt_applicable and from_date and comp_doc:
+        gender, dob = _employee_gender_dob(employee)
+        pt_amt = flt(comp_doc.calculate_pt(gross_salary, gender, period_date, dob))
         deductions.append(row(SC_PT, pt_amt))
 
     # ── LWF ──
@@ -162,6 +162,31 @@ def get_statutory_components(company, gross_salary, from_date,
         employer_share.append(row(SC_EMPR_LWF, _special_component_constant_amount(SC_EMPR_LWF), employer=1))
 
     return {"deductions": deductions, "employer_share": employer_share}
+
+
+def _employee_gender_dob(employee):
+    gender = None
+    dob = None
+    if not employee:
+        return gender, dob
+    if frappe.db.exists("Employee", employee):
+        row = frappe.db.get_value("Employee", employee, ["gender", "date_of_birth"], as_dict=True)
+        if row:
+            gender, dob = row.gender, row.date_of_birth
+    if (not dob or not gender) and frappe.db.exists("Company Link", employee):
+        link = frappe.db.get_value(
+            "Company Link", employee, ["employee", "date_of_birth"], as_dict=True
+        )
+        if link:
+            dob = dob or link.date_of_birth
+            if link.employee and (not dob or not gender):
+                emp = frappe.db.get_value(
+                    "Employee", link.employee, ["gender", "date_of_birth"], as_dict=True
+                )
+                if emp:
+                    gender = gender or emp.gender
+                    dob = dob or emp.date_of_birth
+    return gender, dob
 
 
 def _sum_components(components, gross_salary, earnings_map):

--- a/saral_hr/saral_hr/page/ctc_calculator/ctc_calculator.py
+++ b/saral_hr/saral_hr/page/ctc_calculator/ctc_calculator.py
@@ -22,8 +22,6 @@ EPS_RATE       = 8.33  / 100
 EDLI_RATE      = 0.50  / 100
 PF_ADMIN_RATE  = 0.50  / 100
 EMP_PF_RATE    = 12.00 / 100
-PT_NORMAL      = 200.0
-PT_FEBRUARY    = 300.0
 
 STATUTORY_NAMES = {
     "Employee ESIC", "Employer ESIC",
@@ -59,6 +57,27 @@ DEDUCTION_FORMULAS = {
 }
 
 REMAINDER_KEYWORDS = ["other allowance", "others", "other", "oa", "remainder", "balance"]
+
+_MONTH_TO_NUM = {
+    "January": 1, "February": 2, "March": 3, "April": 4,
+    "May": 5, "June": 6, "July": 7, "August": 8,
+    "September": 9, "October": 10, "November": 11, "December": 12,
+}
+
+
+def _company_pt_amount(company, gross, month_name, gender="Male"):
+    """PT from Company slabs; CTC has no employee — default Male."""
+    if not company:
+        return 0.0
+    try:
+        from frappe.utils import getdate
+        from datetime import date
+        comp = frappe.get_doc("Company", company)
+        month_num = _MONTH_TO_NUM.get(month_name or "January", 1)
+        period_date = date(date.today().year, month_num, 1)
+        return flt(comp.calculate_pt(gross, gender, period_date, None))
+    except Exception:
+        return 0.0
 
 
 # ─── 1. Get companies ─────────────────────────────────────────────────────────
@@ -225,7 +244,6 @@ def calculate_ctc_breakdown(company, salary_structure, annual_ctc, month=None,
     annual_ctc  = flt(annual_ctc)
     monthly_ctc = _round2(annual_ctc / 12)
     month_name  = month or "January"
-    is_february = (month_name == "February")
 
     # ── Statutory flags ───────────────────────────────────────────────────────
     company_stat = _get_company_statutory(company)
@@ -298,7 +316,7 @@ def calculate_ctc_breakdown(company, salary_structure, annual_ctc, month=None,
     # ── Employee deductions ───────────────────────────────────────────────────
     emp_pf       = _round2(pf_wage * EMP_PF_RATE)            if is_pf   else 0.0
     esic_emp_amt = _round2(total_gross * esic_emp_pct / 100) if is_esic else 0.0
-    pt_amount    = (PT_FEBRUARY if is_february else PT_NORMAL) if is_pt  else 0.0
+    pt_amount    = _company_pt_amount(company, total_gross, month_name) if is_pt else 0.0
 
     deductions_out = []
 

--- a/specs/002-maharashtra-professional-tax.md
+++ b/specs/002-maharashtra-professional-tax.md
@@ -8,13 +8,14 @@
 
 ## Why?
 
-Professional Tax (PT) for Maharashtra is slab-based by salary and gender, with a February override and age exemption. Today the app hardcodes ₹200 (₹300 in February) in salary slip / CTC paths and sometimes reads Salary Component monthly amounts. That cannot express real Maharashtra slabs, cannot differ men vs women, and cannot be versioned when rates change.
+Professional Tax (PT) for Maharashtra is slab-based by salary and gender, with a **per-slab** February override (males only for the annual ₹2500 / ₹2200 bands) and age exemption. Females in the taxable band pay ₹200 × 12 = **₹2400/year** — no February surcharge. Flat ₹200/₹300 hardcodes cannot express this.
 
 ## What?
 
 1. **Company → Payroll & Statutory**: configure PT periods and gender slabs (Maharashtra defaults seeded).
 2. **Salary Structure Assignment**: keep only **enable / disable** via `is_pt_applicable` (no PT rate config on the component).
-3. **Salary Slip / CTC / SSA preview**: calculate PT from Company slabs using final (or preview) gross — **remove** all flat ₹200 / ₹300 hardcodes.
+3. **Salary Slip / CTC / SSA preview**: calculate PT from Company slabs using final (or preview) gross — **no** flat ₹200 / ₹300 hardcodes.
+4. **February**: live on each slab as optional `february_amount` (not on the period). Female taxable slabs have no February amount.
 
 ## Decisions (grilling)
 
@@ -23,33 +24,46 @@ Professional Tax (PT) for Maharashtra is slab-based by salary and gender, with a
 | 1 | Taxable base | Final salary-slip **gross** after proration / attendance / additional salary |
 | 2 | Source of truth | Company PT settings only; purge hardcodes everywhere (slip, SSA, CTC) |
 | 3 | Default slabs | Maharashtra seed table below (editable per company) |
-| 4 | February | One period-level `february_amount`; use it **only when matched slab tax > 0** |
+| 4 | ~~February (period)~~ | **Superseded by #15** — was period-level `february_amount` |
 | 5 | Versioning | Periods with `from_date` / `to_date` + SSA lock (same idea as ESIC/PF) |
 | 6 | Gender source | Always **Employee** master `gender` |
 | 7 | Missing / Other gender | Treat as **Male** slabs |
 | 8 | Age exemption | Company period field `age_exempt_years` (default **65**), not a hardcoded constant |
 | 9 | Period + slabs UI model | Period child rows; slabs nested in UX (JSON on period — Frappe cannot nest child tables) |
-| 10 | February rule detail | Nil stays 0 in Feb; taxable slabs use `february_amount` |
+| 10 | ~~February rule (period)~~ | **Superseded by #15–#17** |
 | 11 | Gross timing | Slip uses **final** gross; SSA uses SSA gross as **preview** estimate |
 | 12 | SSA PT row | Still insert PT deduction when enabled; amount = slab estimate from SSA gross |
 | 13 | Salary Component | Migrate: `is_special_component = 0`, clear monthly amounts; keep deduction shell |
 | 14 | v1 scope | Desk Company + salary slip + SSA + CTC calculator/record + unit tests |
+| 15 | February location | **Per-slab** optional `february_amount` (`null` = no Feb override). **Remove** period-level `february_amount` |
+| 16 | Nil + validation | Tax 0 always stays 0 in February; **validation error** if `february_amount` set on a zero-tax slab |
+| 17 | MH Male Feb amounts | Mid band 175 → Feb **275** (₹2200/year); top band 200 → Feb **300** (₹2500/year) |
+| 18 | MH Female Feb | Taxable female slab tax **200**, `february_amount` **null** (₹2400/year, no surcharge) |
+| 19 | Multi-state | **Deferred** — no state picker / engines in this spec; other states = manual slab entry until a later spec |
+| 20 | Migrate existing periods | By tax amount: Male `tax==175` → Feb 275; Male `tax==200` → Feb 300; then drop period `february_amount`. Custom non-175/200 Male slabs get no Feb unless edited later |
+| 21 | Delivery | Amend this spec; continue on `feat/maharashtra-professional-tax` before PR |
 
 ## Default seed (per PT period)
 
-| Gender | From (₹) | To (₹) | Tax (₹/month) |
-|--------|----------|--------|----------------|
-| Male | 0 | 7500 | 0 |
-| Male | 7501 | 10000 | 175 |
-| Male | 10001 | *(open)* | 200 |
-| Female | 0 | 25000 | 0 |
-| Female | 25001 | *(open)* | 200 |
+| Gender | From (₹) | To (₹) | Tax (₹/month) | February (₹) |
+|--------|----------|--------|----------------|--------------|
+| Male | 0 | 7500 | 0 | — |
+| Male | 7501 | 10000 | 175 | **275** |
+| Male | 10001 | *(open)* | 200 | **300** |
+| Female | 0 | 25000 | 0 | — |
+| Female | 25001 | *(open)* | 200 | — |
 
 Period defaults:
 
-- `february_amount` = **300**
 - `age_exempt_years` = **65**
-- Open-ended period (`from_date` / `to_date` empty or company-appropriate start) when seeding empty companies
+- **No** period-level `february_amount`
+- Open-ended period when seeding empty companies
+
+Annual check (Maharashtra):
+
+- Male mid: 175×11 + 275 = **₹2,200**
+- Male top: 200×11 + 300 = **₹2,500**
+- Female taxable: 200×12 = **₹2,400**
 
 ## How?
 
@@ -57,33 +71,35 @@ Period defaults:
 
 Frappe cannot nest a child table inside a child table. Follow the existing ESIC/PF pattern (`wage_components` JSON + custom Desk UI in `company.js`).
 
-#### New child DocType: `Professional Tax Period` (`istable`)
+#### Child DocType: `Professional Tax Period` (`istable`)
 
 | Fieldname | Type | Notes |
 |-----------|------|--------|
 | `from_date` | Date | Period start |
 | `to_date` | Date | Period end; stays editable when SSA-locked |
-| `february_amount` | Currency | Default 300; used when slab tax > 0 and month is February |
 | `age_exempt_years` | Int | Default 65; age ≥ this → PT = 0 |
 | `slabs` | Small Text | JSON array of slab objects |
+
+**Removed:** period field `february_amount` (was in first build — drop via DocType JSON + migrate patch).
 
 Slab JSON shape:
 
 ```json
 [
-  {"gender": "Male", "from_amount": 0, "to_amount": 7500, "tax_amount": 0},
-  {"gender": "Male", "from_amount": 7501, "to_amount": 10000, "tax_amount": 175},
-  {"gender": "Male", "from_amount": 10001, "to_amount": null, "tax_amount": 200},
-  {"gender": "Female", "from_amount": 0, "to_amount": 25000, "tax_amount": 0},
-  {"gender": "Female", "from_amount": 25001, "to_amount": null, "tax_amount": 200}
+  {"gender": "Male", "from_amount": 0, "to_amount": 7500, "tax_amount": 0, "february_amount": null},
+  {"gender": "Male", "from_amount": 7501, "to_amount": 10000, "tax_amount": 175, "february_amount": 275},
+  {"gender": "Male", "from_amount": 10001, "to_amount": null, "tax_amount": 200, "february_amount": 300},
+  {"gender": "Female", "from_amount": 0, "to_amount": 25000, "tax_amount": 0, "february_amount": null},
+  {"gender": "Female", "from_amount": 25001, "to_amount": null, "tax_amount": 200, "february_amount": null}
 ]
 ```
 
-`to_amount: null` = open-ended upper bound.
+`to_amount: null` = open-ended upper bound.  
+`february_amount: null` (or omitted) = use `tax_amount` in all months including February.
 
 #### Company
 
-- New section under **Payroll & Statutory** (after PF): **Professional Tax Slabs**
+- Section under **Payroll & Statutory** (after PF): **Professional Tax Slabs**
 - Table field `pt_periods` → `Professional Tax Period`
 
 ### Calculation
@@ -96,74 +112,78 @@ if DOB set and age(period_date, DOB) >= age_exempt_years → 0
 gender = Employee.gender; if missing or not Male/Female → Male
 match slab for gender where from_amount ≤ gross ≤ to_amount (or open-ended)
 tax = slab.tax_amount (0 if no match)
-if month == February and tax > 0 → february_amount
+if tax == 0 → 0
+if month == February and slab.february_amount is not null → slab.february_amount
 else → tax
 ```
 
-Company helpers (mirror `get_esic_config` / `get_pf_config`):
+Company helpers:
 
-- `get_pt_config(period_date)` → period + parsed slabs
+- `get_pt_config(period_date)` → period + parsed slabs (no period february)
 - `calculate_pt(gross, gender, period_date, date_of_birth)` → float amount
-- `validate_pt_settings()` — non-overlapping periods; valid non-negative ranges; sensible slab coverage within gender
-- `_validate_locked_periods` for PT — when submitted SSA `from_date` falls in period, lock `slabs`, `february_amount`, `age_exempt_years`, `from_date` (`to_date` remains editable)
+- `validate_pt_settings()` — non-overlapping periods; valid non-negative ranges; slab coverage; **reject `february_amount` when `tax_amount == 0`**
+- `_validate_locked_periods` for PT — lock `slabs`, `age_exempt_years`, `from_date` (`to_date` remains editable)
 
 ### Desk UI (`company.js`)
 
-Same pattern as ESIC/PF custom period cards:
-
 - Hide native `pt_periods` grid via CSS
-- Render period cards: dates, February amount, age exempt years
-- Embedded slab editor (gender / from / to / tax) ↔ JSON `slabs`
-- Action: **Load Maharashtra defaults** on new/empty period
+- Period cards: dates, age exempt years (**no** period February field)
+- Slab editor columns: gender / from / to / tax / **February** ↔ JSON `slabs`
+- Action: **Load Maharashtra defaults** (seed table above)
 - Reuse `_is_period_locked` / SSA lock styling
 
-### Call sites (hardcode purge)
+### Call sites
 
-| Location | Change |
-|----------|--------|
-| `salary_slip.py` | Remove `200.0` / `300.0` PT overrides; compute after final gross via `Company.calculate_pt`; age exempt from period setting |
-| `get_statutory_components_internal` | Stop `_sa_local("Professional Tax")`; pass gross + gender + DOB (or compute PT only on slip path after gross is known) |
-| `salary_structure_assignment.py` | Replace `_special_component_amount(SC_PT)` with `calculate_pt(SSA gross, gender, from_date, dob)` preview |
-| `ctc_calculator.py` / `ctc_calculator_record.py` | Remove `PT_NORMAL` / `PT_FEBRUARY`; use Company slabs (default Male if no employee gender) |
-| `install.py` + migrate patch | PT component: `is_special_component=0`, clear monthly amounts; keep `is_pt_component=1` deduction shell |
-
-**Ordering on salary slip:** finalize earnings → gross → then set/replace Professional Tax deduction.
+Already wired to `Company.calculate_pt` in first build — only calc + seed + UI + validation change for February-per-slab. No new hardcodes.
 
 ### Seed / migrate
 
-1. Patch: each Company with empty `pt_periods` → one open period + Maharashtra seed
-2. Patch: Professional Tax Salary Component → not special; clear `monthly_amounts`
-3. Existing SSA `is_pt_applicable` unchanged
+1. **Already done:** empty companies → open period + MH seed; PT component not special
+2. **New patch:** for each PT period row:
+   - Parse `slabs`; for each Male slab: if `tax_amount == 175` set `february_amount = 275`; if `tax_amount == 200` set `february_amount = 300`
+   - Clear / ignore period `february_amount`
+3. Update `MAHARASHTRA_PT_SLABS` constant + “Load Maharashtra defaults” to the table above
+4. Remove `february_amount` from Professional Tax Period DocType JSON
 
 ### Tests (unit)
 
-- Male boundaries: 0 / 175 / 200
-- Female: ≤25000 → 0; above → 200
-- February: tax > 0 → `february_amount`; nil stays 0
+- Male boundaries: 0 / 175 / 200 (non-Feb)
+- Female: ≤25000 → 0; above → 200 **in February too** (no bump)
+- February Male mid: 175 → **275**; Male top: 200 → **300**
+- Nil stays 0 in February
+- Validation: `february_amount` on zero-tax slab → error
 - Age ≥ `age_exempt_years` → 0
 - Missing / Other gender → Male slabs
 - `is_pt_applicable = 0` → no PT
-- No remaining hardcode paths for PT `200`/`300` by month name
 
 No Playwright for v1.
 
 ## Out of scope
 
-- Multi-state PT engines (seed is Maharashtra; other states can be typed into the same editable slabs)
+- Multi-state PT engines / state picker / state seed catalog (manual editable slabs only until a later spec)
 - Playwright e2e
 - LWF / other special components
 - Changing how `is_pt_applicable` is presented on SSA (keep existing toggle)
 
 ## Acceptance criteria
 
+### Done (first build)
+
 - [x] Company form shows Professional Tax section with period + male/female slabs
-- [x] New/empty companies can load (or are seeded with) Maharashtra defaults
-- [x] Salary slip PT uses final gross + gender + age + February rules from Company
+- [x] New/empty companies seeded with Maharashtra defaults
 - [x] Flat ₹200 / ₹300 hardcodes removed from slip, CTC calculator, CTC record
 - [x] SSA only toggles PT; preview amount comes from slabs + SSA gross
 - [x] PT Salary Component is not a special monthly component after migrate
 - [x] SSA-locked periods block slab/rate edits (to_date still editable)
-- [x] Unit tests above pass on the test site
+
+### Remaining (this amendment)
+
+- [ ] Period-level `february_amount` removed; February only on slabs
+- [ ] MH seed: Male 175→Feb 275, Male 200→Feb 300; Female taxable Feb null
+- [ ] Female taxable stays ₹200 in February (₹2400 annual)
+- [ ] Validation rejects `february_amount` on zero-tax slabs
+- [ ] Migrate patch maps existing Male 175/200 slabs to Feb amounts
+- [ ] Unit tests for Female Feb + Male mid/top Feb amounts pass
 
 ## Progress log
 
@@ -172,3 +192,4 @@ No Playwright for v1.
 | 2026-08-04 | Spec written after grilling; status `planned` — await review before build |
 | 2026-08-04 | Build started on `feat/maharashtra-professional-tax` |
 | 2026-08-04 | Implemented: PT Period child + Company slabs UI/helpers; purged 200/300 hardcodes; patches + unit tests green |
+| 2026-08-04 | Re-grilled: Female ₹2400/year (no Feb); per-slab `february_amount`; multi-state deferred; amend spec on same branch |

--- a/specs/002-maharashtra-professional-tax.md
+++ b/specs/002-maharashtra-professional-tax.md
@@ -178,12 +178,12 @@ No Playwright for v1.
 
 ### Remaining (this amendment)
 
-- [ ] Period-level `february_amount` removed; February only on slabs
-- [ ] MH seed: Male 175→Feb 275, Male 200→Feb 300; Female taxable Feb null
-- [ ] Female taxable stays ₹200 in February (₹2400 annual)
-- [ ] Validation rejects `february_amount` on zero-tax slabs
-- [ ] Migrate patch maps existing Male 175/200 slabs to Feb amounts
-- [ ] Unit tests for Female Feb + Male mid/top Feb amounts pass
+- [x] Period-level `february_amount` removed; February only on slabs
+- [x] MH seed: Male 175→Feb 275, Male 200→Feb 300; Female taxable Feb null
+- [x] Female taxable stays ₹200 in February (₹2400 annual)
+- [x] Validation rejects `february_amount` on zero-tax slabs
+- [x] Migrate patch maps existing Male 175/200 slabs to Feb amounts
+- [x] Unit tests for Female Feb + Male mid/top Feb amounts pass
 
 ## Progress log
 
@@ -193,3 +193,4 @@ No Playwright for v1.
 | 2026-08-04 | Build started on `feat/maharashtra-professional-tax` |
 | 2026-08-04 | Implemented: PT Period child + Company slabs UI/helpers; purged 200/300 hardcodes; patches + unit tests green |
 | 2026-08-04 | Re-grilled: Female ₹2400/year (no Feb); per-slab `february_amount`; multi-state deferred; amend spec on same branch |
+| 2026-08-04 | Implemented per-slab February; migrate + tests |

--- a/specs/002-maharashtra-professional-tax.md
+++ b/specs/002-maharashtra-professional-tax.md
@@ -1,0 +1,173 @@
+# 002 — Maharashtra Professional Tax (Company Slabs)
+
+| | |
+|---|---|
+| **Status** | in progress |
+| **Branch** | `feat/maharashtra-professional-tax` |
+| **Primary DocTypes** | Company, Professional Tax Period, Salary Slip, Salary Structure Assignment, Salary Component |
+
+## Why?
+
+Professional Tax (PT) for Maharashtra is slab-based by salary and gender, with a February override and age exemption. Today the app hardcodes ₹200 (₹300 in February) in salary slip / CTC paths and sometimes reads Salary Component monthly amounts. That cannot express real Maharashtra slabs, cannot differ men vs women, and cannot be versioned when rates change.
+
+## What?
+
+1. **Company → Payroll & Statutory**: configure PT periods and gender slabs (Maharashtra defaults seeded).
+2. **Salary Structure Assignment**: keep only **enable / disable** via `is_pt_applicable` (no PT rate config on the component).
+3. **Salary Slip / CTC / SSA preview**: calculate PT from Company slabs using final (or preview) gross — **remove** all flat ₹200 / ₹300 hardcodes.
+
+## Decisions (grilling)
+
+| # | Topic | Decision |
+|---|--------|----------|
+| 1 | Taxable base | Final salary-slip **gross** after proration / attendance / additional salary |
+| 2 | Source of truth | Company PT settings only; purge hardcodes everywhere (slip, SSA, CTC) |
+| 3 | Default slabs | Maharashtra seed table below (editable per company) |
+| 4 | February | One period-level `february_amount`; use it **only when matched slab tax > 0** |
+| 5 | Versioning | Periods with `from_date` / `to_date` + SSA lock (same idea as ESIC/PF) |
+| 6 | Gender source | Always **Employee** master `gender` |
+| 7 | Missing / Other gender | Treat as **Male** slabs |
+| 8 | Age exemption | Company period field `age_exempt_years` (default **65**), not a hardcoded constant |
+| 9 | Period + slabs UI model | Period child rows; slabs nested in UX (JSON on period — Frappe cannot nest child tables) |
+| 10 | February rule detail | Nil stays 0 in Feb; taxable slabs use `february_amount` |
+| 11 | Gross timing | Slip uses **final** gross; SSA uses SSA gross as **preview** estimate |
+| 12 | SSA PT row | Still insert PT deduction when enabled; amount = slab estimate from SSA gross |
+| 13 | Salary Component | Migrate: `is_special_component = 0`, clear monthly amounts; keep deduction shell |
+| 14 | v1 scope | Desk Company + salary slip + SSA + CTC calculator/record + unit tests |
+
+## Default seed (per PT period)
+
+| Gender | From (₹) | To (₹) | Tax (₹/month) |
+|--------|----------|--------|----------------|
+| Male | 0 | 7500 | 0 |
+| Male | 7501 | 10000 | 175 |
+| Male | 10001 | *(open)* | 200 |
+| Female | 0 | 25000 | 0 |
+| Female | 25001 | *(open)* | 200 |
+
+Period defaults:
+
+- `february_amount` = **300**
+- `age_exempt_years` = **65**
+- Open-ended period (`from_date` / `to_date` empty or company-appropriate start) when seeding empty companies
+
+## How?
+
+### Data model
+
+Frappe cannot nest a child table inside a child table. Follow the existing ESIC/PF pattern (`wage_components` JSON + custom Desk UI in `company.js`).
+
+#### New child DocType: `Professional Tax Period` (`istable`)
+
+| Fieldname | Type | Notes |
+|-----------|------|--------|
+| `from_date` | Date | Period start |
+| `to_date` | Date | Period end; stays editable when SSA-locked |
+| `february_amount` | Currency | Default 300; used when slab tax > 0 and month is February |
+| `age_exempt_years` | Int | Default 65; age ≥ this → PT = 0 |
+| `slabs` | Small Text | JSON array of slab objects |
+
+Slab JSON shape:
+
+```json
+[
+  {"gender": "Male", "from_amount": 0, "to_amount": 7500, "tax_amount": 0},
+  {"gender": "Male", "from_amount": 7501, "to_amount": 10000, "tax_amount": 175},
+  {"gender": "Male", "from_amount": 10001, "to_amount": null, "tax_amount": 200},
+  {"gender": "Female", "from_amount": 0, "to_amount": 25000, "tax_amount": 0},
+  {"gender": "Female", "from_amount": 25001, "to_amount": null, "tax_amount": 200}
+]
+```
+
+`to_amount: null` = open-ended upper bound.
+
+#### Company
+
+- New section under **Payroll & Statutory** (after PF): **Professional Tax Slabs**
+- Table field `pt_periods` → `Professional Tax Period`
+
+### Calculation
+
+```
+if not is_pt_applicable → 0
+match Company pt_periods for slip/SSA date
+if no period → 0
+if DOB set and age(period_date, DOB) >= age_exempt_years → 0
+gender = Employee.gender; if missing or not Male/Female → Male
+match slab for gender where from_amount ≤ gross ≤ to_amount (or open-ended)
+tax = slab.tax_amount (0 if no match)
+if month == February and tax > 0 → february_amount
+else → tax
+```
+
+Company helpers (mirror `get_esic_config` / `get_pf_config`):
+
+- `get_pt_config(period_date)` → period + parsed slabs
+- `calculate_pt(gross, gender, period_date, date_of_birth)` → float amount
+- `validate_pt_settings()` — non-overlapping periods; valid non-negative ranges; sensible slab coverage within gender
+- `_validate_locked_periods` for PT — when submitted SSA `from_date` falls in period, lock `slabs`, `february_amount`, `age_exempt_years`, `from_date` (`to_date` remains editable)
+
+### Desk UI (`company.js`)
+
+Same pattern as ESIC/PF custom period cards:
+
+- Hide native `pt_periods` grid via CSS
+- Render period cards: dates, February amount, age exempt years
+- Embedded slab editor (gender / from / to / tax) ↔ JSON `slabs`
+- Action: **Load Maharashtra defaults** on new/empty period
+- Reuse `_is_period_locked` / SSA lock styling
+
+### Call sites (hardcode purge)
+
+| Location | Change |
+|----------|--------|
+| `salary_slip.py` | Remove `200.0` / `300.0` PT overrides; compute after final gross via `Company.calculate_pt`; age exempt from period setting |
+| `get_statutory_components_internal` | Stop `_sa_local("Professional Tax")`; pass gross + gender + DOB (or compute PT only on slip path after gross is known) |
+| `salary_structure_assignment.py` | Replace `_special_component_amount(SC_PT)` with `calculate_pt(SSA gross, gender, from_date, dob)` preview |
+| `ctc_calculator.py` / `ctc_calculator_record.py` | Remove `PT_NORMAL` / `PT_FEBRUARY`; use Company slabs (default Male if no employee gender) |
+| `install.py` + migrate patch | PT component: `is_special_component=0`, clear monthly amounts; keep `is_pt_component=1` deduction shell |
+
+**Ordering on salary slip:** finalize earnings → gross → then set/replace Professional Tax deduction.
+
+### Seed / migrate
+
+1. Patch: each Company with empty `pt_periods` → one open period + Maharashtra seed
+2. Patch: Professional Tax Salary Component → not special; clear `monthly_amounts`
+3. Existing SSA `is_pt_applicable` unchanged
+
+### Tests (unit)
+
+- Male boundaries: 0 / 175 / 200
+- Female: ≤25000 → 0; above → 200
+- February: tax > 0 → `february_amount`; nil stays 0
+- Age ≥ `age_exempt_years` → 0
+- Missing / Other gender → Male slabs
+- `is_pt_applicable = 0` → no PT
+- No remaining hardcode paths for PT `200`/`300` by month name
+
+No Playwright for v1.
+
+## Out of scope
+
+- Multi-state PT engines (seed is Maharashtra; other states can be typed into the same editable slabs)
+- Playwright e2e
+- LWF / other special components
+- Changing how `is_pt_applicable` is presented on SSA (keep existing toggle)
+
+## Acceptance criteria
+
+- [ ] Company form shows Professional Tax section with period + male/female slabs
+- [ ] New/empty companies can load (or are seeded with) Maharashtra defaults
+- [ ] Salary slip PT uses final gross + gender + age + February rules from Company
+- [ ] Flat ₹200 / ₹300 hardcodes removed from slip, CTC calculator, CTC record
+- [ ] SSA only toggles PT; preview amount comes from slabs + SSA gross
+- [ ] PT Salary Component is not a special monthly component after migrate
+- [ ] SSA-locked periods block slab/rate edits (to_date still editable)
+- [ ] Unit tests above pass on the test site
+
+## Progress log
+
+| Date | Note |
+|------|------|
+| 2026-08-04 | Spec written after grilling; status `planned` — await review before build |
+| 2026-08-04 | Build started on `feat/maharashtra-professional-tax` |

--- a/specs/002-maharashtra-professional-tax.md
+++ b/specs/002-maharashtra-professional-tax.md
@@ -156,14 +156,14 @@ No Playwright for v1.
 
 ## Acceptance criteria
 
-- [ ] Company form shows Professional Tax section with period + male/female slabs
-- [ ] New/empty companies can load (or are seeded with) Maharashtra defaults
-- [ ] Salary slip PT uses final gross + gender + age + February rules from Company
-- [ ] Flat ₹200 / ₹300 hardcodes removed from slip, CTC calculator, CTC record
-- [ ] SSA only toggles PT; preview amount comes from slabs + SSA gross
-- [ ] PT Salary Component is not a special monthly component after migrate
-- [ ] SSA-locked periods block slab/rate edits (to_date still editable)
-- [ ] Unit tests above pass on the test site
+- [x] Company form shows Professional Tax section with period + male/female slabs
+- [x] New/empty companies can load (or are seeded with) Maharashtra defaults
+- [x] Salary slip PT uses final gross + gender + age + February rules from Company
+- [x] Flat ₹200 / ₹300 hardcodes removed from slip, CTC calculator, CTC record
+- [x] SSA only toggles PT; preview amount comes from slabs + SSA gross
+- [x] PT Salary Component is not a special monthly component after migrate
+- [x] SSA-locked periods block slab/rate edits (to_date still editable)
+- [x] Unit tests above pass on the test site
 
 ## Progress log
 
@@ -171,3 +171,4 @@ No Playwright for v1.
 |------|------|
 | 2026-08-04 | Spec written after grilling; status `planned` — await review before build |
 | 2026-08-04 | Build started on `feat/maharashtra-professional-tax` |
+| 2026-08-04 | Implemented: PT Period child + Company slabs UI/helpers; purged 200/300 hardcodes; patches + unit tests green |

--- a/specs/PROGRESS.md
+++ b/specs/PROGRESS.md
@@ -5,6 +5,7 @@ Single board for all specs in this folder. New specs get the next number (`002-�
 | # | Spec | Status | Notes |
 |---|------|--------|-------|
 | 001 | [Company list employee counts](./001-company-list-employee-counts.md) | done | List + form headcount from Company Link; tests passing |
+| 002 | [Maharashtra Professional Tax](./002-maharashtra-professional-tax.md) | in progress | Company PT slabs; replace flat ₹200/₹300 |
 
 ## Status legend
 

--- a/specs/PROGRESS.md
+++ b/specs/PROGRESS.md
@@ -5,7 +5,7 @@ Single board for all specs in this folder. New specs get the next number (`002-�
 | # | Spec | Status | Notes |
 |---|------|--------|-------|
 | 001 | [Company list employee counts](./001-company-list-employee-counts.md) | done | List + form headcount from Company Link; tests passing |
-| 002 | [Maharashtra Professional Tax](./002-maharashtra-professional-tax.md) | in progress | Company PT slabs; replace flat ₹200/₹300 |
+| 002 | [Maharashtra Professional Tax](./002-maharashtra-professional-tax.md) | in progress | Per-slab Feb amounts; Female no Feb surcharge; multi-state deferred |
 
 ## Status legend
 


### PR DESCRIPTION
## Why?

Professional Tax was hardcoded as ₹200 (₹300 in February), which cannot express Maharashtra gender slabs, female ₹2400 annual (no Feb surcharge), or versioned rates.

## What?

- Company → Payroll & Statutory: PT periods with gender slabs (Maharashtra defaults seeded)
- Per-slab optional `february_amount` (Male mid 175→275, top 200→300; Female taxable stays 200 year-round)
- Salary slip / SSA / CTC use `Company.calculate_pt` from final/preview gross
- Flat ₹200/₹300 hardcodes removed

## How?

- Child DocType `Professional Tax Period` + Desk period/slab UI (same pattern as ESIC/PF)
- Migrate patches seed MH slabs and move February onto slabs
- Unit tests for slab boundaries, Feb rules, age exempt, validation

## Test plan

- [ ] Company form shows PT section; Load Maharashtra defaults works
- [ ] Male ≥10001 Jan → 200; Feb → 300; mid band Feb → 275
- [ ] Female >25000 Feb → 200 (not 300)
- [ ] SSA PT toggle still works; slip uses final gross
- [ ] CI green


Made with [Cursor](https://cursor.com)