### PR TITLE
feat: Attendance Dashboard yearly headcount & marking coverage

### DIFF
--- a/saral_hr/saral_hr/page/attendance_dashboard/attendance_dashboard.js
+++ b/saral_hr/saral_hr/page/attendance_dashboard/attendance_dashboard.js
@@ -251,10 +251,19 @@ frappe.pages["attendance-dashboard"].on_page_load = function (wrapper) {
 			background:var(--subtle-fg); border-bottom:1px solid var(--border-color);
 		}
 		.ap-yr-tbl thead th:not(:first-child) { text-align:center; }
-		.ap-yr-tbl tbody tr { border-bottom:1px solid var(--border-color); cursor:pointer; transition:background .1s; }
+		.ap-yr-tbl tbody tr { border-bottom:1px solid var(--border-color); transition:background .1s; }
 		.ap-yr-tbl tbody tr:hover { background:var(--highlight-color); }
 		.ap-yr-tbl tbody td { padding:10px 14px; }
-		.ap-yr-tbl tbody td:not(:first-child):not(:last-child) { text-align:center; }
+		.ap-yr-tbl tbody td:not(:first-child) { text-align:center; }
+		.ap-yr-link {
+			cursor:pointer; font-weight:700; color:var(--primary);
+			border-bottom:1px dashed var(--primary); padding:0 2px;
+		}
+		.ap-yr-link:hover { opacity:.8; }
+		.ap-yr-miss {
+			font-size:11px; color:var(--text-muted); margin-top:2px;
+			max-width:280px; white-space:normal; line-height:1.35;
+		}
 
 		/* ── Employee detail drawer ── */
 		.ap-overlay {
@@ -823,94 +832,155 @@ frappe.pages["attendance-dashboard"].on_page_load = function (wrapper) {
 	// ═══════════════════════════════════════════════════════════════════════════
 	function loadYearly(){
 		$main.html(skelCards(4)+skelPanel());
-		let p=12, res={};
-		MONTHS.forEach(m=>{
-			frappe.call({
-				method:"saral_hr.saral_hr.page.attendance_dashboard.attendance_dashboard.get_monthly_summary",
-				args:{company:state.company, year:state.year, month:m, department:state.department},
-				callback(r){ res[m]=r.message; if(--p===0) renderYearly(res); },
-				error(){ res[m]=null; if(--p===0) renderYearly(res); }
-			});
+		frappe.call({
+			method:"saral_hr.saral_hr.page.attendance_dashboard.attendance_dashboard.get_yearly_summary",
+			args:{company:state.company, year:state.year, department:state.department},
+			callback(r){ renderYearly(r.message||{}); },
+			error(){ $main.html(`<div class="ap-empty">Failed to load yearly summary.</div>`); }
 		});
 	}
 
-	function renderYearly(res){
+	function yrLink(val, month, listType){
+		const n = val||0;
+		return `<span class="ap-yr-link" data-month="${frappe.utils.escape_html(month)}" data-type="${listType}">${n}</span>`;
+	}
+
+	function renderYearly(data){
 		$main.empty();
 		setInfo(`<strong>${state.company}</strong> &nbsp;·&nbsp; Year ${state.year}`);
-		let tp=0, ta=0, tl=0, thd=0;
-		MONTHS.forEach(m=>{
-			const d=res[m]; if(!d) return;
-			const ov=d.overall||{};
-			tp  += ["Present","On Tour","Earned Comp Off"].reduce((s,k)=>s+(ov[k]||0),0);
-			ta  += (ov["Absent"]||0)+(ov["LWP"]||0);
-			tl  += ["Earned Leave","Casual Leave","Comp Off"].reduce((s,k)=>s+(ov[k]||0),0);
-			thd += (ov["Half Day"]||0);
-		});
-		const fd = res[MONTHS[0]];
+		const cards = data.cards||{};
+		const months = data.months||[];
 		const $cards = $(`<div class="ap-cards"></div>`).appendTo($main);
 		[
-			{icon:"👥", val:fd?fd.total_active:0, label:"Active",         bg:"#1e40af"},
-			{icon:"🏢", val:tp,                   label:"Phys. Present",  bg:"#15803d"},
-			{icon:"🌴", val:tl,                   label:"Leaves Taken",   bg:"#7c3aed"},
-			{icon:"🌗", val:thd,                  label:"Half Days",      bg:"#b45309"},
-			{icon:"❌", val:ta,                   label:"Absent / LWP",   bg:"#b91c1c"},
-		].forEach(c=>$(`<div class="ap-card" style="background:${c.bg};">
-			<div class="ap-card-icon">${c.icon}</div>
-			<div class="ap-card-num" data-t="${c.val}">0</div>
-			<div class="ap-card-label">${c.label}</div>
-		</div>`).appendTo($cards));
+			{icon:"➕", val:cards.joined||0, label:"Joined", bg:"#15803d"},
+			{icon:"➖", val:cards.left||0, label:"Left", bg:"#b91c1c"},
+			{icon:"👥", val:cards.avg_closing||0, label:"Avg Closing", bg:"#1e40af", raw:true},
+			{icon:"✅", val:cards.marked_coverage_pct||0, label:"Marked Coverage %", bg:"#0e7490", raw:true, suffix:"%"},
+		].forEach(c=>{
+			const display = c.raw ? c.val : 0;
+			const $card = $(`<div class="ap-card" style="background:${c.bg};">
+				<div class="ap-card-icon">${c.icon}</div>
+				<div class="ap-card-num" ${c.raw?"":`data-t="${c.val}"`}>${c.raw?`${c.val}${c.suffix||""}`:"0"}</div>
+				<div class="ap-card-label">${c.label}</div>
+			</div>`);
+			$cards.append($card);
+		});
 		animNums($cards);
 
 		const $p = $(`<div class="ap-panel"></div>`).appendTo($main);
-		$(`<div class="ap-panel-hd"><span class="ap-panel-title">📅 ${state.year} — Month-wise Summary</span></div>`).appendTo($p);
+		$(`<div class="ap-panel-hd"><span class="ap-panel-title">${state.year} — Month-wise Headcount &amp; Marking</span></div>`).appendTo($p);
+
+		if(!months.length){
+			$p.append(`<div class="ap-empty" style="padding:28px;">No completed months for this year yet.</div>`);
+			return;
+		}
+
 		const $tbl = $(`<table class="ap-yr-tbl">
 			<thead><tr>
 				<th>Month</th>
-				<th>Present</th>
-				<th>On Leave</th>
-				<th>Half Day</th>
-				<th>Absent/LWP</th>
-				<th>Holidays</th>
-				<th>Attendance %</th>
+				<th>Opening</th>
+				<th>Joined</th>
+				<th>Left</th>
+				<th>Closing</th>
+				<th>Total Strength</th>
+				<th>Marked</th>
+				<th>Not Marked</th>
 			</tr></thead>
 			<tbody></tbody>
 		</table>`).appendTo($p);
 		const $tb = $tbl.find("tbody");
 
-		MONTHS.forEach(m=>{
-			const d=res[m]; const ov=d?d.overall||{}:{};
-			const pres  = ["Present","On Tour","Earned Comp Off"].reduce((s,k)=>s+(ov[k]||0),0);
-			const leave = ["Earned Leave","Casual Leave","Comp Off"].reduce((s,k)=>s+(ov[k]||0),0);
-			const hday  = ov["Half Day"]||0;
-			const abs   = (ov["Absent"]||0)+(ov["LWP"]||0);
-			const hol   = ov["Holiday"]||0;
-			const mp    = d?d.total_days*(d.total_active||1):0;
-			const pct   = mp>0 ? Math.round((pres/mp)*100) : 0;
-			const bc    = pct>=80?"#22c55e":pct>=60?"#f59e0b":"#ef4444";
-			const isCur = m===MONTHS[TODAY.getMonth()] && state.year===String(TODAY.getFullYear());
-			const $tr   = $(`<tr ${isCur?'style="background:var(--primary-light);"':""}>
-				<td style="font-weight:${isCur?"700":"600"};">${m}${isCur?` <span style="font-size:9px;background:var(--primary);color:#fff;padding:1px 6px;border-radius:6px;margin-left:4px;">Now</span>`:""}</td>
-				<td style="color:#16a34a;font-weight:700;">${pres}</td>
-				<td style="color:#7c3aed;font-weight:700;">${leave}</td>
-				<td style="color:#b45309;font-weight:700;">${hday}</td>
-				<td style="color:#dc2626;font-weight:700;">${abs}</td>
-				<td style="color:#0e7490;font-weight:600;">${hol}</td>
-				<td>
-					<div style="display:flex;align-items:center;gap:7px;">
-						<div class="ap-pct-bg" style="flex:1;">
-							<div class="ap-pct-fill" style="width:${pct}%;background:${bc};"></div>
-						</div>
-						<span style="font-size:11px;font-weight:700;color:${bc};min-width:32px;">${pct}%</span>
-					</div>
-				</td>
+		months.forEach(m=>{
+			const $tr = $(`<tr>
+				<td style="font-weight:600;">${m.month}</td>
+				<td>${yrLink(m.opening, m.month, "opening")}</td>
+				<td>${yrLink(m.joined, m.month, "joined")}</td>
+				<td>${yrLink(m.left, m.month, "left")}</td>
+				<td>${yrLink(m.closing, m.month, "closing")}</td>
+				<td style="font-weight:700;">${m.total_strength||0}</td>
+				<td>${yrLink(m.marked, m.month, "marked")}</td>
+				<td>${yrLink(m.not_marked, m.month, "not_marked")}</td>
 			</tr>`);
-			$tr.on("click",()=>{
-				state.month=m; state.view="monthly";
-				$vFi.find(".ap-vtab").removeClass("active");
-				$vFi.find("[data-v='monthly']").addClass("active");
-				renderPeriodFields(); loadMonthly();
+			$tr.find(".ap-yr-link").on("click", function(e){
+				e.stopPropagation();
+				openYearlyList($(this).data("month"), $(this).data("type"));
 			});
 			$tb.append($tr);
+		});
+	}
+
+	const YR_LIST_TITLES = {
+		opening: "Opening Headcount",
+		joined: "Employees Who Joined",
+		left: "Employees Who Left",
+		closing: "Closing Headcount",
+		marked: "Attendance Marked",
+		not_marked: "Attendance Not Marked",
+	};
+
+	function openYearlyList(month, listType){
+		const title = YR_LIST_TITLES[listType] || listType;
+		const $ov = $(`<div class="ap-overlay"></div>`).appendTo("body");
+		const $dr = $(`<div class="ap-drawer"></div>`).appendTo($ov);
+		$dr.html(`<div class="ap-drawer-hd">
+			<div>
+				<div class="ap-drawer-title">${title}</div>
+				<div class="ap-drawer-sub">${month} ${state.year}</div>
+			</div>
+			<div class="ap-drawer-close">×</div>
+		</div><div class="ap-drawer-body">${skelPanel()}</div>`);
+		$dr.find(".ap-drawer-close").on("click",()=>$ov.remove());
+		$ov.on("click",e=>{ if($(e.target).is($ov)) $ov.remove(); });
+
+		frappe.call({
+			method:"saral_hr.saral_hr.page.attendance_dashboard.attendance_dashboard.get_yearly_employee_list",
+			args:{
+				company: state.company,
+				year: state.year,
+				month,
+				list_type: listType,
+				department: state.department,
+			},
+			callback(r){
+				const d = r.message || {};
+				const emps = d.employees || [];
+				const $b = $dr.find(".ap-drawer-body").empty();
+				$dr.find(".ap-drawer-sub").text(`${month} ${state.year} · ${emps.length} employee${emps.length===1?"":"s"}`);
+
+				if(listType==="not_marked"){
+					const url = d.mark_attendance_url || "/app/mark-attendance";
+					$(`<div style="margin-bottom:12px;">
+						<a class="btn btn-primary btn-sm" href="${url}" target="_blank" rel="noopener">Open Mark Attendance</a>
+					</div>`).appendTo($b);
+				}
+
+				if(!emps.length){
+					$b.append(`<div class="ap-empty">No employees in this list.</div>`);
+					return;
+				}
+
+				buildSearch($b).find("input").on("input", function(){
+					const q = $(this).val().toLowerCase();
+					$b.find(".ap-emp-row").each(function(){
+						$(this).toggle($(this).data("name").toLowerCase().includes(q));
+					});
+				});
+
+				emps.forEach(e=>{
+					const miss = listType==="not_marked"
+						? `<div class="ap-yr-miss"><strong>${e.missing_count||0} missing</strong>${(e.missing_dates||[]).length?`: ${(e.missing_dates||[]).slice(0,8).map(x=>frappe.datetime.str_to_user(x)).join(", ")}${(e.missing_dates||[]).length>8?"…":""}`:""}</div>`
+						: "";
+					const $row = $(`<div class="ap-emp-row" data-name="${frappe.utils.escape_html(e.name||"")}">
+						<div class="ap-av" style="background:hsl(${hueFor(e.name)},55%,42%);">${initials(e.name)}</div>
+						<div class="ap-emp-info">
+							<div class="ap-emp-name">${frappe.utils.escape_html(e.name||e.employee)}</div>
+							<div class="ap-emp-meta">${frappe.utils.escape_html(e.department||"—")} · ${frappe.utils.escape_html(e.designation||"—")}</div>
+							${miss}
+						</div>
+					</div>`);
+					$b.append($row);
+				});
+			}
 		});
 	}
 

--- a/saral_hr/saral_hr/page/attendance_dashboard/attendance_dashboard.py
+++ b/saral_hr/saral_hr/page/attendance_dashboard/attendance_dashboard.py
@@ -417,3 +417,326 @@ def get_employee_monthly_detail(employee, year, month):
         "year":           int(year),
         "month":          month,
     }
+
+
+# ─── Yearly headcount & marking coverage ──────────────────────────────────────
+
+MONTH_NAMES = [
+	"January", "February", "March", "April", "May", "June",
+	"July", "August", "September", "October", "November", "December",
+]
+
+
+def _apply_cl_scope(filters, department=None, permitted=None):
+	"""Return filters, or None if permitted is empty (no access)."""
+	if permitted is not None and len(permitted) == 0:
+		return None
+	if department:
+		filters["department"] = department
+	if permitted is not None:
+		filters["name"] = ["in", permitted]
+	return filters
+
+
+def _on_rolls_at(company, as_of, department=None, permitted=None):
+	"""Company Links on rolls at end of as_of date (joining set, left after as_of)."""
+	as_of = getdate(as_of)
+	filters = _apply_cl_scope(
+		{"company": company, "date_of_joining": ["<=", as_of]},
+		department,
+		permitted,
+	)
+	if filters is None:
+		return []
+	rows = frappe.db.get_all(
+		"Company Link",
+		filters=filters,
+		fields=["name", "full_name", "department", "designation", "left_date"],
+	)
+	return [
+		r for r in rows
+		if not r.left_date or getdate(r.left_date) > as_of
+	]
+
+
+def _joined_in_month(company, month_start, month_end, department=None, permitted=None):
+	filters = _apply_cl_scope(
+		{
+			"company": company,
+			"date_of_joining": ["between", [month_start, month_end]],
+		},
+		department,
+		permitted,
+	)
+	if filters is None:
+		return []
+	return frappe.db.get_all(
+		"Company Link",
+		filters=filters,
+		fields=["name", "full_name", "department", "designation"],
+	)
+
+
+def _left_in_month(company, month_start, month_end, department=None, permitted=None):
+	filters = _apply_cl_scope(
+		{
+			"company": company,
+			"left_date": ["between", [month_start, month_end]],
+		},
+		department,
+		permitted,
+	)
+	if filters is None:
+		return []
+	return frappe.db.get_all(
+		"Company Link",
+		filters=filters,
+		fields=["name", "full_name", "department", "designation"],
+	)
+
+
+def _past_month_nums(year):
+	"""Completed past months of year (exclude current + future)."""
+	today = date.today()
+	year = int(year)
+	if year > today.year:
+		return []
+	if year < today.year:
+		return list(range(1, 13))
+	return list(range(1, today.month))
+
+
+def _prev_month_end(year, month_num):
+	if month_num == 1:
+		return date(year - 1, 12, 31)
+	return get_last_day(date(year, month_num - 1, 1))
+
+
+def _attendance_day_counts(company, employee_ids, month_start, month_end):
+	"""employee -> count of distinct attendance dates in range."""
+	if not employee_ids:
+		return {}
+	rows = frappe.db.sql(
+		"""
+		SELECT employee, COUNT(DISTINCT attendance_date) AS cnt
+		FROM `tabAttendance`
+		WHERE company = %(company)s
+		  AND employee IN %(employees)s
+		  AND attendance_date BETWEEN %(from_date)s AND %(to_date)s
+		GROUP BY employee
+		""",
+		{
+			"company": company,
+			"employees": list(employee_ids),
+			"from_date": str(month_start),
+			"to_date": str(month_end),
+		},
+		as_dict=True,
+	)
+	return {r.employee: int(r.cnt) for r in rows}
+
+
+def _attendance_dates_map(company, employee_ids, month_start, month_end):
+	"""employee -> set of attendance dates (date objects)."""
+	if not employee_ids:
+		return {}
+	rows = frappe.db.sql(
+		"""
+		SELECT employee, attendance_date
+		FROM `tabAttendance`
+		WHERE company = %(company)s
+		  AND employee IN %(employees)s
+		  AND attendance_date BETWEEN %(from_date)s AND %(to_date)s
+		""",
+		{
+			"company": company,
+			"employees": list(employee_ids),
+			"from_date": str(month_start),
+			"to_date": str(month_end),
+		},
+		as_dict=True,
+	)
+	out = {}
+	for r in rows:
+		out.setdefault(r.employee, set()).add(getdate(r.attendance_date))
+	return out
+
+
+def _emp_row(r):
+	return {
+		"employee": r.name,
+		"name": r.full_name or r.name,
+		"department": r.department or "—",
+		"designation": r.designation or "—",
+	}
+
+
+def _month_headcount(company, year, month_num, department=None, permitted=None):
+	month_start = date(int(year), month_num, 1)
+	month_end = get_last_day(month_start)
+	total_days = calendar.monthrange(int(year), month_num)[1]
+	prev_end = _prev_month_end(int(year), month_num)
+
+	opening_rows = _on_rolls_at(company, prev_end, department, permitted)
+	joined_rows = _joined_in_month(company, month_start, month_end, department, permitted)
+	left_rows = _left_in_month(company, month_start, month_end, department, permitted)
+	closing_rows = _on_rolls_at(company, month_end, department, permitted)
+
+	opening_ids = {r.name for r in opening_rows}
+	joined_ids = {r.name for r in joined_rows}
+	strength_ids = opening_ids | joined_ids
+
+	day_counts = _attendance_day_counts(company, strength_ids, month_start, month_end)
+	marked_ids = {eid for eid in strength_ids if day_counts.get(eid, 0) >= total_days}
+	not_marked_ids = strength_ids - marked_ids
+
+	opening = len(opening_ids)
+	joined = len(joined_ids)
+	left = len(left_rows)
+	# Spec identity; tenure closing set used for drill-down
+	closing = opening + joined - left
+
+	return {
+		"month": MONTH_NAMES[month_num - 1],
+		"month_num": month_num,
+		"year": int(year),
+		"opening": opening,
+		"joined": joined,
+		"left": left,
+		"closing": closing,
+		"total_strength": len(strength_ids),
+		"marked": len(marked_ids),
+		"not_marked": len(not_marked_ids),
+		"total_days": total_days,
+		"_opening_rows": opening_rows,
+		"_joined_rows": joined_rows,
+		"_left_rows": left_rows,
+		"_closing_rows": closing_rows,
+		"_strength_ids": strength_ids,
+		"_marked_ids": marked_ids,
+		"_not_marked_ids": not_marked_ids,
+		"_month_start": month_start,
+		"_month_end": month_end,
+	}
+
+
+@frappe.whitelist()
+def get_yearly_summary(company, year, department=None):
+	if not company:
+		return {"months": [], "cards": {}}
+
+	permitted = _get_permitted_employees()
+	year = int(year)
+	months = []
+
+	for month_num in _past_month_nums(year):
+		m = _month_headcount(company, year, month_num, department or None, permitted)
+		months.append({
+			"month": m["month"],
+			"month_num": m["month_num"],
+			"year": m["year"],
+			"opening": m["opening"],
+			"joined": m["joined"],
+			"left": m["left"],
+			"closing": m["closing"],
+			"total_strength": m["total_strength"],
+			"marked": m["marked"],
+			"not_marked": m["not_marked"],
+		})
+
+	total_joined = sum(m["joined"] for m in months)
+	total_left = sum(m["left"] for m in months)
+	avg_closing = round(sum(m["closing"] for m in months) / len(months), 1) if months else 0
+	sum_strength = sum(m["total_strength"] for m in months)
+	sum_marked = sum(m["marked"] for m in months)
+	coverage = round((sum_marked / sum_strength) * 100, 1) if sum_strength else 0
+
+	return {
+		"year": year,
+		"months": months,
+		"cards": {
+			"joined": total_joined,
+			"left": total_left,
+			"avg_closing": avg_closing,
+			"marked_coverage_pct": coverage,
+		},
+	}
+
+
+@frappe.whitelist()
+def get_yearly_employee_list(company, year, month, list_type, department=None):
+	"""
+	list_type: opening | joined | left | closing | marked | not_marked
+	"""
+	if not company or month not in MONTH_NAMES:
+		return {"employees": []}
+
+	month_num = MONTH_NAMES.index(month) + 1
+	if month_num not in _past_month_nums(int(year)):
+		return {"employees": []}
+
+	permitted = _get_permitted_employees()
+	m = _month_headcount(company, int(year), month_num, department or None, permitted)
+
+	if list_type == "opening":
+		return {"employees": [_emp_row(r) for r in m["_opening_rows"]]}
+	if list_type == "joined":
+		return {"employees": [_emp_row(r) for r in m["_joined_rows"]]}
+	if list_type == "left":
+		return {"employees": [_emp_row(r) for r in m["_left_rows"]]}
+	if list_type == "closing":
+		return {"employees": [_emp_row(r) for r in m["_closing_rows"]]}
+
+	# Build name map for strength employees
+	strength = list(m["_strength_ids"])
+	info = {}
+	if strength:
+		for r in frappe.db.get_all(
+			"Company Link",
+			filters={"name": ["in", strength]},
+			fields=["name", "full_name", "department", "designation"],
+		):
+			info[r.name] = r
+
+	if list_type == "marked":
+		emps = []
+		for eid in sorted(m["_marked_ids"], key=lambda x: (info.get(x) or {}).get("full_name") or x):
+			r = info.get(eid)
+			emps.append({
+				"employee": eid,
+				"name": (r.full_name if r else None) or eid,
+				"department": (r.department if r else None) or "—",
+				"designation": (r.designation if r else None) or "—",
+			})
+		return {"employees": emps}
+
+	if list_type == "not_marked":
+		dates_map = _attendance_dates_map(
+			company, m["_not_marked_ids"], m["_month_start"], m["_month_end"]
+		)
+		all_days = [
+			m["_month_start"] + timedelta(days=i)
+			for i in range(m["total_days"])
+		]
+		emps = []
+		for eid in sorted(m["_not_marked_ids"], key=lambda x: (info.get(x) or {}).get("full_name") or x):
+			have = dates_map.get(eid, set())
+			missing = [d for d in all_days if d not in have]
+			r = info.get(eid)
+			emps.append({
+				"employee": eid,
+				"name": (r.full_name if r else None) or eid,
+				"department": (r.department if r else None) or "—",
+				"designation": (r.designation if r else None) or "—",
+				"missing_count": len(missing),
+				"missing_dates": [str(d) for d in missing],
+			})
+		return {
+			"employees": emps,
+			"mark_attendance_url": "/app/mark-attendance",
+			"month": month,
+			"year": int(year),
+			"company": company,
+		}
+
+	return {"employees": []}

--- a/saral_hr/tests/test_attendance_dashboard_yearly.py
+++ b/saral_hr/tests/test_attendance_dashboard_yearly.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026, sj and Contributors
+# See license.txt
+
+import calendar
+from datetime import date, timedelta
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import get_last_day, getdate
+
+from saral_hr.saral_hr.page.attendance_dashboard.attendance_dashboard import (
+	_past_month_nums,
+	get_yearly_employee_list,
+	get_yearly_summary,
+)
+
+
+def _uid() -> str:
+	return frappe.generate_hash(length=6)
+
+
+def _make_company() -> str:
+	uid = _uid()
+	doc = frappe.get_doc(
+		{
+			"doctype": "Company",
+			"company": f"_Test AD Yearly {uid}",
+			"abbr": f"Y{uid}"[:8],
+			"country": "India",
+			"default_currency": "INR",
+			"salary_calculation_based_on": "Exclude Weekly Offs (Working Days)",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_employee(first_name: str | None = None) -> str:
+	doc = frappe.get_doc(
+		{
+			"doctype": "Employee",
+			"naming_series": "HR-EMP-",
+			"first_name": first_name or f"YrEmp{_uid()}",
+			"gender": "Other",
+			"date_of_birth": "1990-01-01",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _ensure_category(name: str = "Staff"):
+	if frappe.db.exists("Category", name):
+		return name
+	doc = frappe.get_doc({"doctype": "Category", "category": name, "has_subtype": 0})
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _ensure_department(name: str) -> str:
+	if frappe.db.exists("Department", name):
+		return name
+	doc = frappe.get_doc({"doctype": "Department", "department": name})
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_company_link(employee, company, joining, left=None, department=None):
+	doc = frappe.get_doc(
+		{
+			"doctype": "Company Link",
+			"employee": employee,
+			"company": company,
+			"category": _ensure_category(),
+			"date_of_joining": getdate(joining),
+			"left_date": getdate(left) if left else None,
+			"is_active": 1,
+			"department": department,
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _mark_days(company, cl, start, end, status="Present"):
+	"""Insert attendance for each day in [start, end] inclusive."""
+	cur = getdate(start)
+	end = getdate(end)
+	while cur <= end:
+		doc = frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"naming_series": "HR-ATT-.YYYY.-",
+				"employee": cl,
+				"company": company,
+				"attendance_date": cur,
+				"status": status,
+			}
+		)
+		doc.flags.ignore_validate = True
+		doc.flags.ignore_mandatory = True
+		doc.insert(ignore_permissions=True)
+		cur += timedelta(days=1)
+
+
+def _month_row(summary, month_name):
+	for m in summary.get("months") or []:
+		if m["month"] == month_name:
+			return m
+	return None
+
+
+class TestAttendanceDashboardYearly(FrappeTestCase):
+	def test_past_month_nums_excludes_current_and_future(self):
+		today = date.today()
+		self.assertEqual(_past_month_nums(today.year + 1), [])
+		self.assertEqual(_past_month_nums(today.year - 1), list(range(1, 13)))
+		self.assertEqual(_past_month_nums(today.year), list(range(1, today.month)))
+
+	def test_opening_jan_uses_dec_prior_year_closing(self):
+		company = _make_company()
+		# On rolls through Dec 2023 → Opening Jan 2024
+		cl_old = _make_company_link(_make_employee(), company, "2023-01-01")
+		# Joined Jan 2024
+		cl_new = _make_company_link(_make_employee(), company, "2024-01-15")
+		# Left Dec 2023 (not in Jan opening)
+		cl_left = _make_company_link(
+			_make_employee(), company, "2023-01-01", left="2023-12-20"
+		)
+
+		summary = get_yearly_summary(company, 2024)
+		jan = _month_row(summary, "January")
+		self.assertIsNotNone(jan)
+		self.assertEqual(jan["opening"], 1)  # only cl_old
+		self.assertEqual(jan["joined"], 1)  # cl_new
+		self.assertEqual(jan["left"], 0)
+		self.assertEqual(jan["closing"], 2)  # opening + joined - left
+		self.assertEqual(jan["total_strength"], 2)  # opening ∪ joined
+		self.assertEqual(jan["marked"] + jan["not_marked"], jan["total_strength"])
+
+	def test_one_missing_day_is_not_marked_absent_full_month_is_marked(self):
+		company = _make_company()
+		cl_full = _make_company_link(_make_employee(), company, "2023-01-01")
+		cl_gap = _make_company_link(_make_employee(), company, "2023-01-01")
+
+		# Full February 2024 for cl_full — all Absent still counts as marked
+		_mark_days(company, cl_full, "2024-02-01", "2024-02-29", status="Absent")
+		# Missing one day for cl_gap
+		_mark_days(company, cl_gap, "2024-02-01", "2024-02-28", status="Present")
+
+		summary = get_yearly_summary(company, 2024)
+		feb = _month_row(summary, "February")
+		self.assertEqual(feb["total_strength"], 2)
+		self.assertEqual(feb["marked"], 1)
+		self.assertEqual(feb["not_marked"], 1)
+
+		not_marked = get_yearly_employee_list(
+			company, 2024, "February", "not_marked"
+		)["employees"]
+		self.assertEqual(len(not_marked), 1)
+		self.assertEqual(not_marked[0]["employee"], cl_gap)
+		self.assertEqual(not_marked[0]["missing_count"], 1)
+		self.assertEqual(not_marked[0]["missing_dates"], ["2024-02-29"])
+
+		marked = get_yearly_employee_list(company, 2024, "February", "marked")[
+			"employees"
+		]
+		self.assertEqual(len(marked), 1)
+		self.assertEqual(marked[0]["employee"], cl_full)
+
+	def test_department_filter_scopes_counts(self):
+		company = _make_company()
+		dept_a = _ensure_department(f"_Test Dept A {_uid()}")
+		dept_b = _ensure_department(f"_Test Dept B {_uid()}")
+		_make_company_link(
+			_make_employee(), company, "2023-01-01", department=dept_a
+		)
+		_make_company_link(
+			_make_employee(), company, "2023-01-01", department=dept_b
+		)
+
+		all_summary = get_yearly_summary(company, 2024)
+		jan_all = _month_row(all_summary, "January")
+		self.assertEqual(jan_all["opening"], 2)
+
+		a_summary = get_yearly_summary(company, 2024, department=dept_a)
+		jan_a = _month_row(a_summary, "January")
+		self.assertEqual(jan_a["opening"], 1)
+		self.assertEqual(jan_a["total_strength"], 1)
+
+	def test_current_year_omits_current_and_future_months(self):
+		company = _make_company()
+		_make_company_link(_make_employee(), company, "2020-01-01")
+		today = date.today()
+		summary = get_yearly_summary(company, today.year)
+		shown = {m["month_num"] for m in summary["months"]}
+		self.assertNotIn(today.month, shown)
+		for future in range(today.month + 1, 13):
+			self.assertNotIn(future, shown)
+		for past in range(1, today.month):
+			self.assertIn(past, shown)

--- a/specs/003-attendance-dashboard-yearly.md
+++ b/specs/003-attendance-dashboard-yearly.md
@@ -1,0 +1,132 @@
+# 003 — Attendance Dashboard yearly headcount & marking coverage
+
+| | |
+|---|---|
+| **Status** | in progress |
+| **Branch** | `feat/attendance-dashboard-yearly` |
+| **Surface** | Desk page `attendance-dashboard` (Yearly tab only) |
+| **Primary sources** | `Company Link`, `Attendance` |
+
+## Why?
+
+Yearly view today rolls up status person-days (`Present`, `On Leave`, `Half Day`, `Absent`, `Holidays`, `Attendance %`). That is the wrong report. Ops need month-wise **headcount movement** plus **whether every calendar day has an Attendance row** (including pre-join / post-left Absents).
+
+## What?
+
+Replace the Yearly table and summary cards. Daily / Monthly tabs unchanged.
+
+### Yearly table columns (final)
+
+| # | Column | Definition |
+|---|---|---|
+| 1 | **Month** | Past completed months of selected year only |
+| 2 | **Opening** | Closing headcount of **previous calendar month** (Jan → Dec of prior year) |
+| 3 | **Joined** | `Company Link` with `date_of_joining` in the month |
+| 4 | **Left** | `Company Link` with `left_date` in the month |
+| 5 | **Closing** | `Opening + Joined − Left` |
+| 6 | **Total strength** | `Opening + Joined` (everyone on rolls at any point in the month) |
+| 7 | **Attendance marked** | Count of strength employees with Attendance for **every calendar day** of the month |
+| 8 | **Attendance not marked** | Count of strength employees missing **≥ 1** calendar day |
+
+Invariants:
+
+- `Marked + Not marked = Total strength`
+- `Opening + Joined − Left = Closing`
+- Status of a day does **not** matter for marked; **row existence** does (Absent before join / after left still = marked)
+
+### Rows shown
+
+- Render **only fully completed past months** of the selected year
+- If selected year is current year: Jan … previous month only
+- If selected year is future: empty table
+- If selected year is past: all 12 months
+
+### Summary cards (yearly)
+
+Replace status rollups with year aggregates over **shown** months:
+
+| Card | Value |
+|---|---|
+| Joined | sum(Joined) |
+| Left | sum(Left) |
+| Avg Closing | mean(Closing) |
+| Marked coverage % | `sum(Marked) / sum(Total strength) × 100` (0 if strength 0) |
+
+### Filters
+
+- Existing **Company**, **Year**, **Department** apply to all columns
+- Employee user-permissions (same as today) apply
+
+### Drill-downs (all counts clickable)
+
+| Click | List content |
+|---|---|
+| Opening / Joined / Left / Closing | Employee name, department, designation |
+| **Attendance marked** | Name, department, designation only |
+| **Attendance not marked** | Name, department, designation + **missing day count** + **missing dates** + action/link to **Mark Attendance** |
+
+### Dropped from yearly
+
+- Present / On Leave / Half Day / Absent-LWP / Holidays / Attendance %
+- Average attendance / Attendance strength
+- Holidays column
+
+## How?
+
+### Backend
+
+New whitelisted APIs on `attendance_dashboard.py`:
+
+- `get_yearly_summary(company, year, department=None)` — single call for all past months
+- `get_yearly_employee_list(company, year, month, list_type, department=None)` — drill-down
+
+Per included month:
+
+1. **Opening** = Closing of prior month (always previous Closing; Jan uses Dec of `year-1`)
+2. **Joined / Left** = count `Company Link` by `date_of_joining` / `left_date` in range (+ dept + permissions)
+3. **Closing** = Opening + Joined − Left
+4. **Strength pool** = Opening set ∪ Joined set
+5. Marked = distinct attendance dates for month == calendar days in month
+
+Closing / Opening sets use tenure dates (not only `is_active`):
+
+- On rolls at month end: `date_of_joining <= month_end` AND (`left_date` is null OR `left_date > month_end`)
+
+### Frontend
+
+- Rewrite `loadYearly` / `renderYearly` to call `get_yearly_summary` once
+- New columns + cards; click → drawer lists
+- Not marked: missing dates + Mark Attendance CTA (`/app/mark-attendance`)
+
+### Tests
+
+Unit/integration tests for:
+
+- Opening(Jan Y) = Closing(Dec Y−1)
+- Marked + Not marked = Strength; Opening + Joined − Left = Closing
+- One missing day → Not marked
+- Absent on all days still Marked
+- Current month excluded from rows
+- Department filter scopes pool and counts
+
+## Out of scope
+
+- Daily / Monthly tab redesign
+- Changing Mark Attendance outside-tenure Absent logic
+- Changing Overview headcount formulas
+- Export / PDF
+
+## Acceptance
+
+1. Yearly columns match the table above; old status columns gone
+2. Jan opening comes from prior December closing
+3. Past months only; current/future months absent
+4. Marked/Not marked based on full calendar-day row coverage
+5. All six counts open employee lists; Not marked has missing dates + Mark Attendance link
+6. Department filter works; cards show Joined / Left / Avg Closing / Marked coverage %
+
+## Progress log
+
+| Date | Note |
+|------|------|
+| 2026-08-06 | Spec grilled and written |

--- a/specs/003-attendance-dashboard-yearly.md
+++ b/specs/003-attendance-dashboard-yearly.md
@@ -130,3 +130,4 @@ Unit/integration tests for:
 | Date | Note |
 |------|------|
 | 2026-08-06 | Spec grilled and written |
+| 2026-08-06 | Implemented yearly API + UI; unit tests passing |

--- a/specs/PROGRESS.md
+++ b/specs/PROGRESS.md
@@ -6,6 +6,7 @@ Single board for all specs in this folder. New specs get the next number (`002-â
 |---|------|--------|-------|
 | 001 | [Company list employee counts](./001-company-list-employee-counts.md) | done | List + form headcount from Company Link; tests passing |
 | 002 | [Maharashtra Professional Tax](./002-maharashtra-professional-tax.md) | in progress | Per-slab Feb amounts; Female no Feb surcharge; multi-state deferred |
+| 003 | [Attendance Dashboard yearly](./003-attendance-dashboard-yearly.md) | in progress | Yearly headcount + full-calendar marking coverage |
 
 ## Status legend
 


### PR DESCRIPTION
## Why?

Yearly view was rolling up status person-days (Present / Leave / Half Day / Absent / Holidays / %). Ops need month-wise headcount movement and whether every calendar day has an Attendance row.

## What?

- Spec `003` for yearly headcount + marking coverage
- Yearly columns: Opening, Joined, Left, Closing, Total Strength, Marked, Not Marked
- Opening always comes from previous month Closing (Jan ← Dec prior year)
- Past completed months only; Marked = full calendar-day row coverage
- Clickable counts with employee lists; Not Marked includes missing dates + Mark Attendance link
- Summary cards: Joined, Left, Avg Closing, Marked Coverage %
- Unit tests for identities, opening, missing day, department filter, current-month exclusion

## How?

New `get_yearly_summary` / `get_yearly_employee_list` APIs on the attendance dashboard page; yearly UI rewritten to use them instead of 12× monthly status rollups.


Made with [Cursor](https://cursor.com)