### PR TITLE
fix: Monthly Salary Register module path (scrub mismatch)

### DIFF
--- a/saral_hr/patches.txt
+++ b/saral_hr/patches.txt
@@ -9,3 +9,4 @@ saral_hr.patches.backfill_company_employee_counts
 saral_hr.patches.seed_maharashtra_pt_periods
 saral_hr.patches.clear_pt_special_component
 saral_hr.patches.migrate_pt_february_to_slabs
+saral_hr.patches.delete_broken_monthly_salary_register_report

--- a/saral_hr/patches/delete_broken_monthly_salary_register_report.py
+++ b/saral_hr/patches/delete_broken_monthly_salary_register_report.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+	"""Drop broken report name whose scrub() is not a valid Python module."""
+	old = "Monthly Salary Register (Old Format) Net Payable"
+	if frappe.db.exists("Report", old):
+		frappe.delete_doc("Report", old, force=1, ignore_permissions=True)

--- a/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.js
+++ b/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.js
@@ -1,4 +1,4 @@
-frappe.query_reports["Monthly Salary Register (Old Format) Net Payable"] = {
+frappe.query_reports["Monthly Salary Register Old Format Net Payable"] = {
 	filters: [
 		{
 			fieldname: "company",
@@ -89,7 +89,7 @@ function _export(report, method, freeze_msg) {
 	}
 	frappe.dom.freeze(freeze_msg);
 	frappe.call({
-		method: `saral_hr.saral_hr.report.monthly_salary_register_old_format.monthly_salary_register_old_format.${method}`,
+		method: `saral_hr.saral_hr.report.monthly_salary_register_old_format_net_payable.monthly_salary_register_old_format_net_payable.${method}`,
 		args: { filters: JSON.stringify(f) },
 		callback(r) {
 			frappe.dom.unfreeze();

--- a/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.json
+++ b/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.json
@@ -12,11 +12,11 @@
  "modified": "2026-08-06 13:30:00.000000",
  "modified_by": "Administrator",
  "module": "Saral Hr",
- "name": "Monthly Salary Register (Old Format) Net Payable",
+ "name": "Monthly Salary Register Old Format Net Payable",
  "owner": "Administrator",
  "prepared_report": 0,
  "ref_doctype": "Salary Slip",
- "report_name": "Monthly Salary Register (Old Format) Net Payable",
+ "report_name": "Monthly Salary Register Old Format Net Payable",
  "report_type": "Script Report",
  "roles": [
   {

--- a/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.py
+++ b/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, sj and Contributors
 # See license.txt
 
-"""Monthly Salary Register (Old Format) Net Payable — Desk + PDF + Excel."""
+"""Monthly Salary Register Old Format Net Payable — Desk + PDF + Excel."""
 
 from __future__ import annotations
 

--- a/saral_hr/tests/test_monthly_salary_register.py
+++ b/saral_hr/tests/test_monthly_salary_register.py
@@ -5,7 +5,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import getdate
 
-from saral_hr.saral_hr.report.monthly_salary_register_old_format.monthly_salary_register_old_format import (
+from saral_hr.saral_hr.report.monthly_salary_register_old_format_net_payable.monthly_salary_register_old_format_net_payable import (
 	build_register,
 	_act_fn,
 	_earn_fn,

--- a/specs/004-monthly-salary-register.md
+++ b/specs/004-monthly-salary-register.md
@@ -14,7 +14,9 @@ Payroll ops still use a wide “Employee Salary Sheet” (one row per employee) 
 
 ## What?
 
-New report: **Monthly Salary Register (Old Format) Net Payable**
+New report: **Monthly Salary Register Old Format Net Payable**
+
+> Desk report name cannot include parentheses — Frappe `scrub()` would produce an invalid Python module (`monthly_salary_register_(old_format)_net_payable`).
 
 - One row per employee for a selected company + month
 - PDF + Excel with the same column model, color bands, totals row, and signature block
@@ -147,7 +149,7 @@ Reuse patterns from `salary_summary` PDF helpers where practical; keep this repo
 
 ## How? (implementation sketch)
 
-1. New Script Report under Saral HR: `Monthly Salary Register (Old Format) Net Payable`
+1. New Script Report under Saral HR: `Monthly Salary Register Old Format Net Payable`
 2. `execute(filters)` → columns + data for Desk
 3. Whitelisted export methods (or report-js buttons) for PDF / Excel
 4. Data pipeline per month:
@@ -172,7 +174,7 @@ Company + one past month with ≥2 submitted Staff slips → Desk rows → PDF d
 
 ## Acceptance
 
-1. Report appears as **Monthly Salary Register (Old Format) Net Payable**
+1. Report appears as **Monthly Salary Register Old Format Net Payable**
 2. Filters: Company, Year, Month, Population (All/Staff/Worker/Consultant)
 3. Only submitted slips; one row per slip/employee
 4. Day columns match mapping above; OD & I blank; HD/ECO/LWP not shown
@@ -204,7 +206,7 @@ Company + one past month with ≥2 submitted Staff slips → Desk rows → PDF d
 | Excel | Same columns + totals |
 | Colors | PDF + Excel |
 | Signatures | Yes |
-| Name | Monthly Salary Register (Old Format) Net Payable |
+| Name | Monthly Salary Register Old Format Net Payable (no parentheses — scrub must be a valid module) |
 
 ## Progress log
 
@@ -212,3 +214,4 @@ Company + one past month with ≥2 submitted Staff slips → Desk rows → PDF d
 |------|------|
 | 2026-08-06 | Grilled from sample screenshot; spec written (planned) |
 | 2026-08-06 | Implemented Script Report + PDF/Excel; unit tests passing |
+| 2026-08-06 | Fix: drop parentheses from report name so scrub() matches module path |


### PR DESCRIPTION
## Problem

Opening **Monthly Salary Register (Old Format) Net Payable** raised `ModuleNotFoundError` for `monthly_salary_register_(old_format)_net_payable` — parentheses are not a valid Python package name after `frappe.scrub()`.

## Solution

- Rename report to **Monthly Salary Register Old Format Net Payable**
- Rename module package to match scrub: `monthly_salary_register_old_format_net_payable`
- Patch deletes the broken Report document on migrate


Made with [Cursor](https://cursor.com)