### PR TITLE
feat: Monthly Salary Register Compressed format

### DIFF
--- a/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.js
+++ b/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.js
@@ -66,25 +66,127 @@ frappe.query_reports["Monthly Salary Register Old Format Net Payable"] = {
 		report.page.add_inner_button(__("Download Excel"), () => {
 			_export(report, "excel_report", __("Generating Excel…"));
 		});
+		_ensure_header_wrap_styles();
 	},
 
 	formatter(value, row, column, data, default_formatter) {
 		if (!data) return default_formatter(value, row, column, data);
 		const def = (v) => default_formatter(v, row, column, data);
 		const fn = column.fieldname;
+
 		if (data._is_total) {
-			const skip = ["bank_name", "ifsc", "bank_account", "total_month_day", "sr_no"];
+			const skip = [
+				"bank_name",
+				"ifsc",
+				"bank_account",
+				"total_month_day",
+				"total_paid_days",
+				"sr_no",
+			];
 			if (skip.includes(fn)) {
 				return "";
 			}
 			return `<strong>${def(value)}</strong>`;
 		}
-		if (["total_gross", "total_earning", "total_deductions", "net_payable"].includes(fn)) {
-			return `<span style="background:#ffff99;padding:0 4px;">${def(value)}</span>`;
+
+		if (fn === "total_paid_days" && value !== null && value !== undefined && value !== "") {
+			const n = flt(value);
+			return Math.abs(n - Math.round(n)) < 1e-9 ? String(Math.round(n)) : String(flt(n, 1));
 		}
+
 		return def(value);
 	},
+
+	after_datatable_render(datatable) {
+		_pin_total_row_on_sort(datatable);
+		_ensure_header_wrap_styles();
+		_widen_serial_column(datatable);
+	},
 };
+
+function _widen_serial_column(datatable) {
+	const dm = datatable && datatable.datamanager;
+	if (!dm) return;
+	const idx = dm.getColumnIndexById("_rowIndex");
+	if (idx < 0) return;
+	const col = dm.getColumn(idx);
+	col.width = 46;
+	datatable.columnmanager.setColumnWidth(idx, 46);
+	datatable.columnmanager.setColumnHeaderWidth(idx);
+}
+
+function _ensure_header_wrap_styles() {
+	const id = "saral-msr-header-wrap";
+	let style = document.getElementById(id);
+	if (!style) {
+		style = document.createElement("style");
+		style.id = id;
+		document.head.appendChild(style);
+	}
+	// One-sided horizontal padding — breathing room without overflowing the page.
+	style.textContent = `
+		.report-wrapper .dt-row-header {
+			height: auto !important;
+		}
+		.report-wrapper .dt-cell--header {
+			height: 60px !important;
+		}
+		.report-wrapper .dt-cell--header .dt-cell__content {
+			white-space: normal !important;
+			overflow: visible !important;
+			text-overflow: clip !important;
+			height: 100% !important;
+			min-height: 56px !important;
+			line-height: 1.3 !important;
+			padding: 8px 4px 8px 8px !important;
+			display: flex !important;
+			flex-direction: column !important;
+			justify-content: center !important;
+			align-items: center !important;
+			text-align: center !important;
+			box-sizing: border-box !important;
+		}
+		.report-wrapper .dt-cell:not(.dt-cell--header) .dt-cell__content {
+			padding: 6px 2px 6px 8px !important;
+		}
+		.report-wrapper .dt-cell__content--col-0,
+		.report-wrapper .dt-cell__content--header-0 {
+			padding-left: 10px !important;
+			padding-right: 2px !important;
+			text-align: center !important;
+			justify-content: center !important;
+		}
+		.report-wrapper .dt-scrollable .dt-row:hover .dt-cell {
+			background-color: var(--subtle-fg, #edf2f7) !important;
+		}
+		.report-wrapper .dt-scrollable .dt-row:hover .dt-cell__content {
+			background-color: transparent !important;
+		}
+	`;
+}
+
+function _pin_total_row_on_sort(datatable) {
+	const dm = datatable && datatable.datamanager;
+	if (!dm || dm.__saral_total_sort_patched) return;
+	dm.__saral_total_sort_patched = true;
+	const orig = dm._sortRows.bind(dm);
+	dm._sortRows = function (colIndex, sortOrder) {
+		orig(colIndex, sortOrder);
+		const name_col = this.getColumnIndexById("employee_name");
+		if (name_col < 0) return;
+		const totals = [];
+		const rest = [];
+		for (const idx of this.rowViewOrder) {
+			const cell = this.getCell(name_col, idx);
+			if (cell && cell.content === "Total") {
+				totals.push(idx);
+			} else {
+				rest.push(idx);
+			}
+		}
+		this.rowViewOrder = rest.concat(totals);
+	};
+}
 
 function _export(report, method, freeze_msg) {
 	const f = report.get_values();

--- a/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.js
+++ b/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.js
@@ -49,6 +49,14 @@ frappe.query_reports["Monthly Salary Register Old Format Net Payable"] = {
 			default: "All",
 			options: ["All", "Staff", "Worker", "Consultant"].join("\n"),
 		},
+		{
+			fieldname: "format",
+			label: __("Format"),
+			fieldtype: "Select",
+			reqd: 1,
+			default: "Full",
+			options: ["Full", "Compressed"].join("\n"),
+		},
 	],
 
 	onload(report) {
@@ -65,12 +73,13 @@ frappe.query_reports["Monthly Salary Register Old Format Net Payable"] = {
 		const def = (v) => default_formatter(v, row, column, data);
 		const fn = column.fieldname;
 		if (data._is_total) {
-			if (["bank_name", "ifsc", "bank_account", "total_month_day", "sr_no"].includes(fn)) {
-				return fn === "employee_name" ? `<strong>${def(value)}</strong>` : "";
+			const skip = ["bank_name", "ifsc", "bank_account", "total_month_day", "sr_no"];
+			if (skip.includes(fn)) {
+				return "";
 			}
 			return `<strong>${def(value)}</strong>`;
 		}
-		if (["total_gross", "total_earning", "net_payable"].includes(fn)) {
+		if (["total_gross", "total_earning", "total_deductions", "net_payable"].includes(fn)) {
 			return `<span style="background:#ffff99;padding:0 4px;">${def(value)}</span>`;
 		}
 		return def(value);

--- a/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.py
+++ b/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.py
@@ -13,7 +13,7 @@ from datetime import date
 
 import frappe
 from frappe import _
-from frappe.utils import flt, get_last_day, getdate
+from frappe.utils import cint, flt, get_last_day, getdate
 from frappe.utils.pdf import get_pdf
 
 from openpyxl import Workbook
@@ -49,23 +49,22 @@ DAY_COLS = [
 ]
 
 IDENTITY_FNS = {"sr_no", "employee_name", "bank_name", "ifsc", "bank_account"}
-HIGHLIGHT_FNS = {"total_gross", "total_earning", "total_deductions", "net_payable"}
 COMPRESSED_FORMAT = "Compressed"
 FULL_FORMAT = "Full"
 
 ACTUAL_HDR = "#F4A460"
 EARN_HDR = "#90EE90"
 DED_HDR = "#F08080"
-YELLOW = "#FFFF99"
 SIG = (
-	'<div style="display:flex;justify-content:space-between;margin-top:28px;padding-top:8px;">'
+	'<table style="width:100%;margin-top:36px;border-collapse:collapse;table-layout:fixed;">'
+	"<tr>"
 	+ "".join(
-		f'<div style="text-align:center;width:160px;">'
-		f'<div style="border-top:1px solid #000;margin-bottom:4px;"></div>'
-		f'<div style="font-size:10px;">{lbl}</div></div>'
+		f'<td style="width:33.33%;text-align:center;vertical-align:top;padding:0 12px;">'
+		f'<div style="border-top:1px solid #000;margin:0 auto 6px auto;width:85%;"></div>'
+		f'<div style="font-size:10px;">{lbl}</div></td>'
 		for lbl in ("Prepared By", "Checked By", "Authorised Signatory")
 	)
-	+ "</div>"
+	+ "</tr></table>"
 )
 
 
@@ -270,7 +269,7 @@ def _load_slips(company, start, end, population):
 		  AND ss.start_date = %(start)s
 		  AND ss.end_date = %(end)s
 		  {cat_clause}
-		ORDER BY ss.employee_name ASC, ss.employee ASC
+		ORDER BY IFNULL(NULLIF(cl.employee, ''), ss.employee) ASC
 		""",
 		params,
 		as_dict=True,
@@ -396,18 +395,65 @@ def _empty_columns():
 
 
 def _compressed_columns():
+	# Desk already shows DataTable serial — no SR. NO. column.
+	# <br> = two-line headers (Desk / PDF); Excel swaps to \\n.
 	return [
-		_col("SR. NO.", "sr_no", "Int", 50),
-		_col("Full Name", "employee_name", width=180),
-		_col("IFSC Code", "ifsc", width=110),
-		_col("Account Number", "bank_account", width=130),
-		_col("Days in Month", "total_month_day", "Int", 80),
-		_col("Paid For Days", "total_paid_days", "Float", 90, precision=1),
-		_col("Actual Gross", "total_gross", "Currency", 110),
-		_col("Earning Gross", "total_earning", "Currency", 110),
-		_col("Deductions", "total_deductions", "Currency", 110),
-		_col("Net Payable", "net_payable", "Currency", 110),
+		_col("Full<br>Name", "employee_name", width=180),
+		_col("IFSC<br>Code", "ifsc", width=140, align="left"),
+		_col("Account<br>Number", "bank_account", width=165, align="left"),
+		_col("Days in<br>Month", "total_month_day", "Int", 90),
+		_col("Paid For<br>Days", "total_paid_days", "Float", 95, precision=1),
+		_col("Actual<br>Gross", "total_gross", "Currency", 120),
+		_col("Earning<br>Gross", "total_earning", "Currency", 120),
+		_col("Deductions", "total_deductions", "Currency", 115),
+		_col("Net<br>Payable", "net_payable", "Currency", 120),
 	]
+
+
+def _fmt_paid_days(val):
+	"""Whole days without .0; keep one decimal only when fractional."""
+	if val is None or val == "":
+		return ""
+	v = flt(val)
+	if abs(v - round(v)) < 1e-9:
+		return str(int(round(v)))
+	return f"{v:.1f}"
+
+
+def _columns_for_export(payload):
+	"""PDF/Excel keep an SR. NO. (Desk uses DataTable serial instead)."""
+	cols = list(payload["columns"])
+	if payload.get("meta", {}).get("format") == COMPRESSED_FORMAT:
+		cols = [_col("SR.<br>NO.", "sr_no", "Int", 45)] + cols
+	return cols
+
+
+def _colgroup_html(cols):
+	"""Proportional <col> widths so PDF does not force equal columns."""
+	total = sum(cint(c.get("width") or 100) for c in cols) or 1
+	parts = []
+	for c in cols:
+		pct = 100.0 * cint(c.get("width") or 100) / total
+		parts.append(f'<col style="width:{pct:.2f}%">')
+	return "<colgroup>" + "".join(parts) + "</colgroup>"
+
+
+def _excel_col_width(col):
+	"""Map Desk px-ish widths to Excel character widths (breathing room)."""
+	fn = col.get("fieldname")
+	px = cint(col.get("width") or 100)
+	# Excel width ≈ characters; tune bank fields so IFSC / account don't clip
+	if fn == "sr_no":
+		return 6
+	if fn == "employee_name":
+		return max(18, int(px / 9))
+	if fn == "ifsc":
+		return max(14, int(px / 9))
+	if fn == "bank_account":
+		return max(16, int(px / 9))
+	if fn in ("total_gross", "total_earning", "total_deductions", "net_payable"):
+		return max(12, int(px / 9))
+	return max(10, int(px / 9))
 
 
 def _fixed_columns(actual_comps, earn_comps, ded_comps):
@@ -415,8 +461,8 @@ def _fixed_columns(actual_comps, earn_comps, ded_comps):
 		_col("SR. NO.", "sr_no", "Int", 50),
 		_col("Full Name Of The Employee", "employee_name", width=180),
 		_col("BANK", "bank_name", width=90),
-		_col("IFSC", "ifsc", width=110),
-		_col("BANK ACCOUNT NO", "bank_account", width=130),
+		_col("IFSC", "ifsc", width=130, align="left"),
+		_col("BANK ACCOUNT NO", "bank_account", width=140, align="left"),
 		_col("TOTAL MONTH DAY", "total_month_day", "Int", 70),
 	]
 	for fn, lbl, _ in DAY_COLS:
@@ -474,10 +520,10 @@ def _compressed_totals_row(rows):
 		"ifsc": "",
 		"bank_account": "",
 		"total_month_day": "",
+		"total_paid_days": "",
 		"_is_total": 1,
 	}
 	for fn in (
-		"total_paid_days",
 		"total_gross",
 		"total_earning",
 		"total_deductions",
@@ -498,7 +544,7 @@ def print_report(filters):
 
 
 def _build_html(payload):
-	cols = payload["columns"]
+	cols = _columns_for_export(payload)
 	data = payload["data"]
 	meta = payload["meta"]
 	company = meta.get("company") or ""
@@ -508,51 +554,67 @@ def _build_html(payload):
 	if start and end:
 		period = f"{start.strftime('%d-%b-%Y')} to {end.strftime('%d-%b-%Y')}"
 
+	compressed = meta.get("format") == COMPRESSED_FORMAT
 	actual_set = {_act_fn(c) for c in meta.get("actual_comps") or []}
 	earn_set = {_earn_fn(c) for c in meta.get("earn_comps") or []}
 	ded_set = {_ded_fn(c) for c in meta.get("ded_comps") or []}
 
 	def hdr_bg(fn):
+		if compressed:
+			return "#f0f0f0"
 		if fn in actual_set or fn == "total_gross":
 			return ACTUAL_HDR
 		if fn in earn_set or fn == "total_earning":
 			return EARN_HDR
 		if fn in ded_set or fn == "total_deductions":
 			return DED_HDR
-		if fn == "net_payable":
-			return YELLOW
 		return "#f0f0f0"
 
 	th = "".join(
-		f'<th style="border:1px solid #000;padding:2px;font-size:6.5px;background:{hdr_bg(c["fieldname"])};">'
+		f'<th style="padding:4px 6px 4px 8px;font-size:6.5px;'
+		f'background:{hdr_bg(c["fieldname"])};vertical-align:middle;">'
 		f'{c["label"]}</th>'
 		for c in cols
 	)
 
 	body = ""
+	data_idx = 0
 	for row in data:
 		tds = ""
 		is_tot = row.get("_is_total")
+		if not is_tot:
+			data_idx += 1
 		for c in cols:
 			fn = c["fieldname"]
 			val = row.get(fn)
 			if val is None or val == "":
 				disp = ""
+			elif fn == "total_paid_days":
+				disp = "" if is_tot else _fmt_paid_days(val)
 			elif isinstance(val, float):
 				disp = f"{val:,.2f}"
 			else:
 				disp = str(val)
-			bg = YELLOW if fn in HIGHLIGHT_FNS else ("#e8e8e8" if is_tot else "#fff")
+			if is_tot:
+				bg = "#e8e8e8"
+			elif data_idx % 2 == 0:
+				bg = "#f5f5f5"
+			else:
+				bg = "#fff"
 			align = "left" if fn in ("employee_name", "bank_name", "ifsc", "bank_account") else "right"
 			if fn == "sr_no":
 				align = "center"
-			weight = "bold" if is_tot or fn in HIGHLIGHT_FNS else "normal"
+			weight = "bold" if is_tot else "normal"
+			pad = "2px 4px 2px 8px"
+			row_cls = "tot" if is_tot else "data"
 			tds += (
-				f'<td style="border:1px solid #000;padding:1px 2px;font-size:6.5px;'
-				f'text-align:{align};background:{bg};font-weight:{weight};">{disp}</td>'
+				f'<td class="{row_cls}" style="padding:{pad};font-size:6.5px;'
+				f'text-align:{align};background:{bg};font-weight:{weight};'
+				f'white-space:nowrap;overflow:hidden;">{disp}</td>'
 			)
 		body += f"<tr>{tds}</tr>"
 
+	colgroup = _colgroup_html(cols)
 	return f"""<!DOCTYPE html><html><head><meta charset="UTF-8">
 <style>
 *{{margin:0;padding:0;box-sizing:border-box}}
@@ -562,13 +624,33 @@ body{{font-family:Arial,sans-serif;font-size:7px;color:#000}}
 .hdr .ttl{{font-size:12px;font-weight:700;margin-top:2px}}
 .hdr .per{{font-size:10px;margin-top:2px}}
 table{{width:100%;border-collapse:collapse;table-layout:fixed}}
+th,td{{word-wrap:break-word}}
+/* Vertical lines stay solid; horizontal lines in data area are thin dashed */
+th{{
+  border-left:1px solid #000;
+  border-right:1px solid #000;
+  border-top:1px solid #000;
+  border-bottom:1px solid #000;
+}}
+td.data{{
+  border-left:1px solid #000;
+  border-right:1px solid #000;
+  border-top:none;
+  border-bottom:0.5px dashed #999;
+}}
+td.tot{{
+  border-left:1px solid #000;
+  border-right:1px solid #000;
+  border-top:1px solid #000;
+  border-bottom:1px solid #000;
+}}
 </style></head><body>
 <div class="hdr">
   <div class="co">{frappe.utils.escape_html(company)}</div>
   <div class="ttl">Employee Salary Sheet</div>
   <div class="per">For the Period {period} &nbsp;|&nbsp; Month Days: {meta.get("month_days") or ""}</div>
 </div>
-<table><thead><tr>{th}</tr></thead><tbody>{body}</tbody></table>
+<table>{colgroup}<thead><tr>{th}</tr></thead><tbody>{body}</tbody></table>
 {SIG}
 </body></html>"""
 
@@ -582,7 +664,8 @@ def _save_pdf(html, prefix):
 			"margin-top": "6mm",
 			"margin-right": "4mm",
 			"margin-bottom": "6mm",
-			"margin-left": "4mm",
+			# Extra left margin for filing / hole-punch
+			"margin-left": "18mm",
 			"encoding": "UTF-8",
 			"no-outline": None,
 		},
@@ -615,7 +698,7 @@ def excel_report(filters):
 
 
 def _build_workbook(payload):
-	cols = payload["columns"]
+	cols = _columns_for_export(payload)
 	data = payload["data"]
 	meta = payload["meta"]
 	wb = Workbook()
@@ -645,30 +728,30 @@ def _build_workbook(payload):
 	c2.font = Font(name="Arial", size=10)
 	c2.alignment = Alignment(horizontal="center")
 
+	compressed = meta.get("format") == COMPRESSED_FORMAT
 	actual_set = {_act_fn(c) for c in meta.get("actual_comps") or []}
 	earn_set = {_earn_fn(c) for c in meta.get("earn_comps") or []}
 	ded_set = {_ded_fn(c) for c in meta.get("ded_comps") or []}
 
 	def fill_for(fn):
+		if compressed:
+			return PatternFill("solid", fgColor="F0F0F0")
 		if fn in actual_set or fn == "total_gross":
 			return PatternFill("solid", fgColor="F4A460")
 		if fn in earn_set or fn == "total_earning":
 			return PatternFill("solid", fgColor="90EE90")
 		if fn in ded_set or fn == "total_deductions":
 			return PatternFill("solid", fgColor="F08080")
-		if fn == "net_payable" or fn in HIGHLIGHT_FNS:
-			return PatternFill("solid", fgColor="FFFF99")
 		return PatternFill("solid", fgColor="F0F0F0")
 
 	hdr_row = 4
 	for i, col in enumerate(cols, start=1):
-		cell = ws.cell(hdr_row, i, col["label"])
+		cell = ws.cell(hdr_row, i, (col["label"] or "").replace("<br>", "\n"))
 		cell.font = Font(name="Arial", size=8, bold=True)
 		cell.fill = fill_for(col["fieldname"])
 		cell.border = thin
 		cell.alignment = Alignment(horizontal="center", wrap_text=True, vertical="center")
 
-	yellow = PatternFill("solid", fgColor="FFFF99")
 	tot_fill = PatternFill("solid", fgColor="E8E8E8")
 
 	for r_idx, row in enumerate(data, start=hdr_row + 1):
@@ -681,27 +764,50 @@ def _build_workbook(payload):
 			cell = ws.cell(r_idx, c_idx, val if val != "" else None)
 			cell.font = Font(name="Arial", size=8, bold=bool(is_tot))
 			cell.border = thin
-			if fn in HIGHLIGHT_FNS:
-				cell.fill = yellow
-			elif is_tot:
+			if is_tot:
 				cell.fill = tot_fill
-			if col.get("fieldtype") in ("Currency", "Float") and isinstance(val, (int, float)):
+			if is_tot and fn == "total_paid_days":
+				cell.value = None
+			elif fn == "bank_account" or fn == "ifsc":
+				cell.alignment = Alignment(horizontal="left")
+			elif fn == "total_paid_days" and isinstance(val, (int, float)):
+				v = flt(val)
+				if abs(v - round(v)) < 1e-9:
+					cell.value = int(round(v))
+					cell.number_format = "0"
+				else:
+					cell.number_format = "0.0"
+				cell.alignment = Alignment(horizontal="right")
+			elif col.get("fieldtype") in ("Currency", "Float") and isinstance(val, (int, float)):
 				cell.number_format = "#,##0.00"
 				cell.alignment = Alignment(horizontal="right")
 
-	# Signatures
+	# Signatures — one row, equally spaced across the sheet
 	sig_row = hdr_row + len(data) + 3
-	for i, lbl in enumerate(("Prepared By", "Checked By", "Authorised Signatory")):
-		col = 2 + i * 4
-		if col > len(cols):
-			break
-		ws.cell(sig_row, col, "________________")
-		ws.cell(sig_row + 1, col, lbl).font = Font(name="Arial", size=9)
+	labels = ("Prepared By", "Checked By", "Authorised Signatory")
+	n_cols = max(len(cols), 1)
+	# place each label at the center of its third of the columns
+	for i, lbl in enumerate(labels):
+		start = int(i * n_cols / 3) + 1
+		end = int((i + 1) * n_cols / 3)
+		if end < start:
+			end = start
+		mid = (start + end) // 2
+		if start != end:
+			ws.merge_cells(start_row=sig_row, start_column=start, end_row=sig_row, end_column=end)
+			ws.merge_cells(
+				start_row=sig_row + 1, start_column=start, end_row=sig_row + 1, end_column=end
+			)
+		line = ws.cell(sig_row, start, "________________")
+		line.alignment = Alignment(horizontal="center")
+		line.font = Font(name="Arial", size=9)
+		lab = ws.cell(sig_row + 1, start, lbl)
+		lab.alignment = Alignment(horizontal="center")
+		lab.font = Font(name="Arial", size=9)
 
-	for i in range(1, len(cols) + 1):
-		ws.column_dimensions[get_column_letter(i)].width = 11
-	ws.column_dimensions["B"].width = 22
-	ws.row_dimensions[hdr_row].height = 30
+	for i, col in enumerate(cols, start=1):
+		ws.column_dimensions[get_column_letter(i)].width = _excel_col_width(col)
+	ws.row_dimensions[hdr_row].height = 32
 	return wb
 
 

--- a/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.py
+++ b/saral_hr/saral_hr/report/monthly_salary_register_old_format_net_payable/monthly_salary_register_old_format_net_payable.py
@@ -49,7 +49,9 @@ DAY_COLS = [
 ]
 
 IDENTITY_FNS = {"sr_no", "employee_name", "bank_name", "ifsc", "bank_account"}
-HIGHLIGHT_FNS = {"total_gross", "total_earning", "net_payable"}
+HIGHLIGHT_FNS = {"total_gross", "total_earning", "total_deductions", "net_payable"}
+COMPRESSED_FORMAT = "Compressed"
+FULL_FORMAT = "Full"
 
 ACTUAL_HDR = "#F4A460"
 EARN_HDR = "#90EE90"
@@ -75,29 +77,35 @@ def execute(filters=None):
 def build_register(filters):
 	"""Build columns + data + meta for Desk / PDF / Excel."""
 	f = _normalize_filters(filters)
+	compressed = f.format == COMPRESSED_FORMAT
+	base_meta = {
+		"company": f.company,
+		"month": f.month,
+		"year": f.year,
+		"format": f.format,
+		"actual_comps": [],
+		"earn_comps": [],
+		"ded_comps": [],
+	}
+
 	if not f.company or not f.year or not f.month:
-		return {"columns": _empty_columns(), "data": [], "meta": {}}
+		return {
+			"columns": _compressed_columns() if compressed else _empty_columns(),
+			"data": [],
+			"meta": base_meta,
+		}
 
 	start = date(int(f.year), MONTH_MAP[f.month], 1)
 	end = getdate(get_last_day(start))
 	month_days = calendar.monthrange(int(f.year), MONTH_MAP[f.month])[1]
+	base_meta.update({"start": str(start), "end": str(end), "month_days": month_days})
 
 	slips = _load_slips(f.company, start, end, f.population)
 	if not slips:
 		return {
-			"columns": _fixed_columns([] , [], []),
+			"columns": _compressed_columns() if compressed else _fixed_columns([], [], []),
 			"data": [],
-			"meta": {
-				"company": f.company,
-				"month": f.month,
-				"year": f.year,
-				"start": str(start),
-				"end": str(end),
-				"month_days": month_days,
-				"actual_comps": [],
-				"earn_comps": [],
-				"ded_comps": [],
-			},
+			"meta": base_meta,
 		}
 
 	cl_ids = [s.employee for s in slips]
@@ -106,12 +114,16 @@ def build_register(filters):
 	emp_map = _employee_bank_map(emp_ids)
 
 	ssa_by_cl = {}
+	for s in slips:
+		ssa_by_cl[s.employee] = _resolve_ssa(s.employee, start, end)
+
+	if compressed:
+		return _build_compressed(slips, cl_map, emp_map, ssa_by_cl, month_days, base_meta)
+
 	actual_union = []
 	seen_act = set()
 	for s in slips:
-		ssa_name = _resolve_ssa(s.employee, start, end)
-		ssa_by_cl[s.employee] = ssa_name
-		for comp, amt in _ssa_earnings(ssa_name):
+		for comp, amt in _ssa_earnings(ssa_by_cl.get(s.employee)):
 			if comp not in seen_act:
 				seen_act.add(comp)
 				actual_union.append(comp)
@@ -177,20 +189,42 @@ def build_register(filters):
 	if rows:
 		rows.append(_totals_row(rows, actual_union, earn_union, ded_union, month_days))
 
+	base_meta.update({
+		"actual_comps": actual_union,
+		"earn_comps": earn_union,
+		"ded_comps": ded_union,
+	})
+	return {"columns": columns, "data": rows, "meta": base_meta}
+
+
+def _build_compressed(slips, cl_map, emp_map, ssa_by_cl, month_days, base_meta):
+	rows = []
+	for idx, s in enumerate(slips, start=1):
+		cl = cl_map.get(s.employee) or {}
+		emp = emp_map.get(cl.get("employee")) or {}
+		ssa_amts = dict(_ssa_earnings(ssa_by_cl.get(s.employee)))
+		gross = flt(sum(flt(v) for v in ssa_amts.values()), 2)
+		rows.append({
+			"sr_no": idx,
+			"employee_name": s.employee_name or cl.get("full_name") or s.employee,
+			"ifsc": emp.get("ifsc_code") or "",
+			"bank_account": emp.get("account_number") or "",
+			"total_month_day": month_days,
+			"total_paid_days": flt(s.payment_days),
+			"total_gross": gross,
+			"total_earning": flt(s.total_earnings),
+			"total_deductions": flt(s.total_deductions),
+			"net_payable": flt(s.net_salary),
+			"_is_total": 0,
+		})
+
+	if rows:
+		rows.append(_compressed_totals_row(rows))
+
 	return {
-		"columns": columns,
+		"columns": _compressed_columns(),
 		"data": rows,
-		"meta": {
-			"company": f.company,
-			"month": f.month,
-			"year": f.year,
-			"start": str(start),
-			"end": str(end),
-			"month_days": month_days,
-			"actual_comps": actual_union,
-			"earn_comps": earn_union,
-			"ded_comps": ded_union,
-		},
+		"meta": base_meta,
 	}
 
 
@@ -205,6 +239,8 @@ def _normalize_filters(filters):
 	if pop.lower() == "all":
 		pop = "All"
 	f.population = pop
+	fmt = (f.get("format") or FULL_FORMAT).strip()
+	f.format = COMPRESSED_FORMAT if fmt == COMPRESSED_FORMAT else FULL_FORMAT
 	return f
 
 
@@ -359,6 +395,21 @@ def _empty_columns():
 	return _fixed_columns([], [], [])
 
 
+def _compressed_columns():
+	return [
+		_col("SR. NO.", "sr_no", "Int", 50),
+		_col("Full Name", "employee_name", width=180),
+		_col("IFSC Code", "ifsc", width=110),
+		_col("Account Number", "bank_account", width=130),
+		_col("Days in Month", "total_month_day", "Int", 80),
+		_col("Paid For Days", "total_paid_days", "Float", 90, precision=1),
+		_col("Actual Gross", "total_gross", "Currency", 110),
+		_col("Earning Gross", "total_earning", "Currency", 110),
+		_col("Deductions", "total_deductions", "Currency", 110),
+		_col("Net Payable", "net_payable", "Currency", 110),
+	]
+
+
 def _fixed_columns(actual_comps, earn_comps, ded_comps):
 	cols = [
 		_col("SR. NO.", "sr_no", "Int", 50),
@@ -413,6 +464,26 @@ def _totals_row(rows, actual_comps, earn_comps, ded_comps, month_days):
 	for fn, _, field in DAY_COLS:
 		if not field:
 			tot[fn] = None
+	return tot
+
+
+def _compressed_totals_row(rows):
+	tot = {
+		"sr_no": "",
+		"employee_name": "Total",
+		"ifsc": "",
+		"bank_account": "",
+		"total_month_day": "",
+		"_is_total": 1,
+	}
+	for fn in (
+		"total_paid_days",
+		"total_gross",
+		"total_earning",
+		"total_deductions",
+		"net_payable",
+	):
+		tot[fn] = flt(sum(flt(r.get(fn)) for r in rows), 2)
 	return tot
 
 

--- a/saral_hr/tests/test_monthly_salary_register.py
+++ b/saral_hr/tests/test_monthly_salary_register.py
@@ -309,3 +309,60 @@ class TestMonthlySalaryRegister(FrappeTestCase):
 		self.assertEqual(tot["_is_total"], 1)
 		self.assertEqual(tot["employee_name"], "Total")
 		self.assertEqual(tot["net_payable"], payload["data"][0]["net_payable"] + payload["data"][1]["net_payable"])
+
+	def test_compressed_format_ten_columns_and_totals(self):
+		company = _make_company()
+		structure = _make_structure(company)
+		cl = _make_cl(_make_employee(bank="HDFC", ifsc="HDFC0001", acct="998877"), company)
+		_make_ssa(cl, company, structure, basic=10000, hra=2000)
+		_make_slip(cl, company, employee_name="Comp Emp")
+
+		full = build_register(
+			{
+				"company": company,
+				"year": "2024",
+				"month": "June",
+				"population": "All",
+				"format": "Full",
+			}
+		)
+		compressed = build_register(
+			{
+				"company": company,
+				"year": "2024",
+				"month": "June",
+				"population": "All",
+				"format": "Compressed",
+			}
+		)
+
+		labels = [c["label"] for c in compressed["columns"]]
+		self.assertEqual(
+			labels,
+			[
+				"SR. NO.",
+				"Full Name",
+				"IFSC Code",
+				"Account Number",
+				"Days in Month",
+				"Paid For Days",
+				"Actual Gross",
+				"Earning Gross",
+				"Deductions",
+				"Net Payable",
+			],
+		)
+		self.assertEqual(compressed["meta"]["format"], "Compressed")
+
+		full_row = [r for r in full["data"] if not r.get("_is_total")][0]
+		row = [r for r in compressed["data"] if not r.get("_is_total")][0]
+		self.assertEqual(row["ifsc"], "HDFC0001")
+		self.assertEqual(row["bank_account"], "998877")
+		self.assertNotIn("bank_name", row)
+		self.assertNotIn("day_p", row)
+		self.assertEqual(row["total_gross"], full_row["total_gross"])
+		self.assertEqual(row["total_earning"], full_row["total_earning"])
+		self.assertEqual(row["total_deductions"], full_row["total_deductions"])
+		self.assertEqual(row["net_payable"], full_row["net_payable"])
+		self.assertEqual(row["total_paid_days"], full_row["total_paid_days"])
+		self.assertEqual(row["total_month_day"], 30)

--- a/saral_hr/tests/test_monthly_salary_register.py
+++ b/saral_hr/tests/test_monthly_salary_register.py
@@ -340,19 +340,32 @@ class TestMonthlySalaryRegister(FrappeTestCase):
 		self.assertEqual(
 			labels,
 			[
-				"SR. NO.",
-				"Full Name",
-				"IFSC Code",
-				"Account Number",
-				"Days in Month",
-				"Paid For Days",
-				"Actual Gross",
-				"Earning Gross",
+				"Full<br>Name",
+				"IFSC<br>Code",
+				"Account<br>Number",
+				"Days in<br>Month",
+				"Paid For<br>Days",
+				"Actual<br>Gross",
+				"Earning<br>Gross",
 				"Deductions",
-				"Net Payable",
+				"Net<br>Payable",
 			],
 		)
+		self.assertEqual(len(compressed["columns"]), 9)
+		self.assertNotIn("sr_no", [c["fieldname"] for c in compressed["columns"]])
 		self.assertEqual(compressed["meta"]["format"], "Compressed")
+
+		from saral_hr.saral_hr.report.monthly_salary_register_old_format_net_payable.monthly_salary_register_old_format_net_payable import (
+			_fmt_paid_days,
+		)
+
+		self.assertEqual(_fmt_paid_days(28.0), "28")
+		self.assertEqual(_fmt_paid_days(28.5), "28.5")
+		self.assertEqual(_fmt_paid_days(287.5), "287.5")
+
+		tot = [r for r in compressed["data"] if r.get("_is_total")][0]
+		self.assertEqual(tot["total_paid_days"], "")
+		self.assertTrue(tot["total_gross"] > 0)
 
 		full_row = [r for r in full["data"] if not r.get("_is_total")][0]
 		row = [r for r in compressed["data"] if not r.get("_is_total")][0]
@@ -366,3 +379,61 @@ class TestMonthlySalaryRegister(FrappeTestCase):
 		self.assertEqual(row["net_payable"], full_row["net_payable"])
 		self.assertEqual(row["total_paid_days"], full_row["total_paid_days"])
 		self.assertEqual(row["total_month_day"], 30)
+
+	def test_default_sort_by_employee_id(self):
+		company = _make_company()
+		structure = _make_structure(company)
+		# Create in reverse name order but assert rows follow Employee name (id)
+		emps = []
+		for label in ("Zed", "Amy"):
+			emp = _make_employee()
+			emps.append(emp)
+			cl = _make_cl(emp, company)
+			_make_ssa(cl, company, structure, basic=10000, hra=1000)
+			_make_slip(cl, company, employee_name=f"{label} Person")
+
+		payload = build_register(
+			{"company": company, "year": "2024", "month": "June", "population": "All"}
+		)
+		rows = [r for r in payload["data"] if not r.get("_is_total")]
+		expected_order = sorted(emps)
+		name_by_emp = {}
+		for emp, label in zip(emps, ("Zed", "Amy")):
+			name_by_emp[emp] = f"{label} Person"
+		self.assertEqual(
+			[r["employee_name"] for r in rows],
+			[name_by_emp[e] for e in expected_order],
+		)
+
+	def test_pdf_colgroup_uses_proportional_widths(self):
+		from saral_hr.saral_hr.report.monthly_salary_register_old_format_net_payable.monthly_salary_register_old_format_net_payable import (
+			_build_html,
+			_colgroup_html,
+			_compressed_columns,
+			_columns_for_export,
+		)
+		import re
+
+		cols = _columns_for_export(
+			{"columns": _compressed_columns(), "meta": {"format": "Compressed"}}
+		)
+		html = _colgroup_html(cols)
+		self.assertIn("<colgroup>", html)
+		self.assertEqual(html.count("<col "), len(cols))
+		pcts = [float(x) for x in re.findall(r"width:([0-9.]+)%", html)]
+		ifsc_i = next(i for i, c in enumerate(cols) if c["fieldname"] == "ifsc")
+		days_i = next(i for i, c in enumerate(cols) if c["fieldname"] == "total_month_day")
+		self.assertGreater(pcts[ifsc_i], pcts[days_i])
+
+		payload = {
+			"columns": _compressed_columns(),
+			"data": [],
+			"meta": {
+				"company": "X",
+				"format": "Compressed",
+				"month_days": 30,
+			},
+		}
+		full_html = _build_html(payload)
+		self.assertIn("<colgroup>", full_html)
+		self.assertIn("table-layout:fixed", full_html)

--- a/specs/004-monthly-salary-register.md
+++ b/specs/004-monthly-salary-register.md
@@ -35,7 +35,7 @@ New report: **Monthly Salary Register Old Format Net Payable**
 
 - Only **submitted** Salary Slips (`docstatus = 1`) for that company + month
 - Population filter applied via Company Link category (All = no category filter)
-- Sort: employee name ascending (SR. NO. assigned after sort)
+- Sort: Employee ID ascending (`Company Link.employee`, fallback Salary Slip employee); SR. NO. assigned after sort
 - Employees on salary hold with no submitted slip: **excluded** (no row)
 
 ### Report header
@@ -215,3 +215,4 @@ Company + one past month with ≥2 submitted Staff slips → Desk rows → PDF d
 | 2026-08-06 | Grilled from sample screenshot; spec written (planned) |
 | 2026-08-06 | Implemented Script Report + PDF/Excel; unit tests passing |
 | 2026-08-06 | Fix: drop parentheses from report name so scrub() matches module path |
+| 2026-08-07 | Default sort changed to Employee ID (shared with 005 Compressed) |

--- a/specs/005-monthly-salary-register-compressed.md
+++ b/specs/005-monthly-salary-register-compressed.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | in progress |
+| **Status** | ready for review |
 | **Branch** | `feat/monthly-salary-register-compressed` |
 | **Depends on** | [004 — Monthly Salary Register Old Format](./004-monthly-salary-register.md) |
 | **Surface** | Extend existing Script Report **Monthly Salary Register Old Format Net Payable** |
@@ -19,24 +19,28 @@ Add a **Format** filter to the existing report:
 | Value | Behavior |
 |-------|----------|
 | `Full` | Current 004 layout (identity + day codes + dynamic ACTUAL/Earning/Deduction comps + net) |
-| `Compressed` | Fixed 10-column layout below |
+| `Compressed` | Fixed 9 data-column layout below (+ Desk serial / export SR. NO.) |
 
-Filters otherwise unchanged: Company, Year, Month, Population (All/Staff/Worker/Consultant). Inclusion rules same as 004 (submitted slips only, sort by name, exclude holds with no slip).
+Filters otherwise unchanged: Company, Year, Month, Population (All/Staff/Worker/Consultant). Inclusion rules same as 004 (submitted slips only, sort by **Employee ID**, exclude holds with no slip).
+
+### Sort (Full + Compressed)
+
+Default order: **Employee ID** ascending (`Company Link.employee`, fallback Salary Slip `employee`). SR. NO. assigned after that order.
 
 ### Compressed columns (exact)
 
-| # | Column | Source |
-|---|--------|--------|
-| 1 | SR. NO. | Row index (1-based) |
-| 2 | Full Name | Slip `employee_name` / Company Link `full_name` |
-| 3 | IFSC Code | Employee `ifsc_code` |
-| 4 | Account Number | Employee `account_number` |
-| 5 | Days in Month | Calendar days in month |
-| 6 | Paid For Days | Slip `payment_days` |
-| 7 | Actual Gross | Sum of SSA earning amounts (same as Full **Total Gross**) |
-| 8 | Earning Gross | Slip `total_earnings` (same as Full **Total Earning**) |
-| 9 | Deductions | Slip `total_deductions` (employee-share total) |
-| 10 | Net Payable | Slip `net_salary` |
+| # | Column | Source / notes |
+|---|--------|----------------|
+| — | Serial | Desk: DataTable built-in `_rowIndex` (no duplicate SR. NO. column). PDF/Excel prepend **SR. NO.** |
+| 1 | Full Name | Slip `employee_name` / Company Link `full_name` |
+| 2 | IFSC Code | Employee `ifsc_code` (left-aligned; wide enough for 11-char IFSC) |
+| 3 | Account Number | Employee `account_number` (left-aligned) |
+| 4 | Days in Month | Calendar days in month |
+| 5 | Paid For Days | Slip `payment_days` — whole numbers without `.0`; one decimal when fractional; **no sum on Total row** |
+| 6 | Actual Gross | Sum of SSA earning amounts (same as Full **Total Gross**) |
+| 7 | Earning Gross | Slip `total_earnings` (same as Full **Total Earning**) |
+| 8 | Deductions | Slip `total_deductions` (employee-share total) |
+| 9 | Net Payable | Slip `net_salary` |
 
 **Dropped vs Full in Compressed:**
 
@@ -44,18 +48,40 @@ Filters otherwise unchanged: Company, Year, Month, Population (All/Staff/Worker/
 - All day letter-codes (P / R / H / C / T / Y / OD / E / I / A)
 - All per-component ACTUAL / Earning / Deduction columns
 
+### Desk UX
+
+- Multi-word Compressed headers wrap to **two lines** (`<br>`); header row tall enough to show both lines
+- Column widths sized for content with **one-sided** horizontal padding (avoid page overflow)
+- Serial column widened so digits are not clipped
+- **No yellow** highlight on Actual / Earning / Deductions / Net
+- Total row stays **pinned at bottom** when sorting any column
+- Row **hover** highlight on Desk grid
+- Currency figures use default Currency formatter (no invalid `span` wrap around Currency `<div>`)
+
 ### Header / footer / exports
 
 - Header same idea as Full (`Employee Salary Sheet` + period + Month Days)
-- Totals row: sum numeric money/day columns; identity blank or “Total”
-- Signatures: Prepared / Checked / Authorised (same as Full)
-- PDF: A4 landscape; Excel: same columns as Desk for the selected format
-- Highlight Net Payable (and optionally Actual Gross / Earning Gross) in yellow — match Full highlight spirit
-- No ACTUAL/Earning/Deduction color **component bands** in Compressed (no component blocks)
+- Totals row: sum money columns (Actual Gross, Earning Gross, Deductions, Net); identity blank or “Total”; Paid For Days blank on Total
+- Signatures: **Prepared By / Checked By / Authorised Signatory** in **one row**, equally spaced (PDF table layout — wkhtmltopdf does not honour flexbox; Excel merged thirds)
+- PDF: A4 landscape
+- Excel: same column model + proportional widths aligned to Desk
+- No ACTUAL/Earning/Deduction color **component bands** in Compressed
+
+### PDF layout details
+
+| Topic | Decision |
+|-------|----------|
+| Column widths | `<colgroup>` with **proportional** widths from column defs (not equal-width) |
+| Vertical borders | Solid (unchanged) |
+| Horizontal borders (data rows) | Thin **dashed** |
+| Header / Total borders | Solid |
+| Zebra rows | Odd/even data-row backgrounds for readability |
+| Left margin | **18mm** for filing / hole-punch; other margins stay tight |
+| Signatures | Single equidistant row under the table |
 
 ### Desk / PDF / Excel
 
-All three use the Compressed column model when Format = Compressed. Full exports unchanged when Format = Full.
+All three use the Compressed column model when Format = Compressed. Full exports unchanged when Format = Full (except shared sort-by-Employee-ID and shared PDF signature / margin / border polish where applicable).
 
 ### Default Format
 
@@ -64,9 +90,10 @@ All three use the Compressed column model when Format = Compressed. Full exports
 ## How? (implementation sketch)
 
 1. Add `format` filter: `Full` \| `Compressed` (default `Full`)
-2. Reuse `build_register` data pipeline; when Compressed, project each row to the 10 fields above (skip building dynamic component columns)
-3. PDF/Excel builders branch on format (or share a slim table renderer for Compressed)
-4. Tests: Compressed column count/labels; Actual Gross = SSA sum; Earning/Deductions/Net match slip; Full mode regression smoke
+2. Reuse `build_register` data pipeline; when Compressed, project each row to the fields above (skip building dynamic component columns)
+3. PDF/Excel builders branch on format; PDF uses colgroup + zebra + dashed horizontals; Excel uses `_excel_col_width`
+4. Desk JS: two-line header CSS, serial widen, pin Total on sort, hover, Paid For Days display formatter
+5. Tests: Compressed column count/labels; paid-days formatting; no paid-days total; Employee ID sort; PDF colgroup proportions; Full mode regression smoke
 
 ### Naming note
 
@@ -75,28 +102,38 @@ Keep Desk report name **Monthly Salary Register Old Format Net Payable** (no new
 ## Out of scope
 
 - New standalone report DocType/name
-- Changing Full layout or day-code mapping from 004
+- Changing Full day-code mapping from 004
 - Per-component breakdown in Compressed
 - BANK name column in Compressed
 
 ## Acceptance
 
 1. Format filter Full / Compressed works
-2. Compressed shows exactly the 10 columns listed
+2. Compressed shows the 9 data columns listed (Desk serial is separate; PDF/Excel prepend SR. NO.)
 3. Values match Full’s Total Gross / Total Earning / Total Deductions / Net / Paid Days for the same slips
-4. PDF + Excel export Compressed correctly
-5. Full mode behavior unchanged
+4. PDF + Excel export Compressed correctly (proportional columns, signatures in one row, dashed data horizontals, 18mm left margin, zebra rows)
+5. Full mode behavior unchanged aside from shared Employee ID sort and shared PDF chrome polish
+6. Paid For Days: whole numbers without `.0`; one decimal when fractional; blank on Total
+7. Desk: two-line headers readable; Total pinned on sort; row hover; IFSC/Account not clipped; Account left-aligned
 
 ## Decisions log (grilling)
 
 | Topic | Decision |
 |-------|----------|
 | Surface | Same report + Format filter (`Full` / `Compressed`) |
-| Compressed columns | SR, Full Name, IFSC, Account Number, Days in Month, Paid For Days, Actual Gross, Earning Gross, Deductions, Net Payable |
+| Compressed columns | 9 data cols; Desk uses DT serial; PDF/Excel prepend SR. NO. |
 | BANK name | Dropped in Compressed |
 | Day codes | Dropped in Compressed |
 | Component columns | Dropped in Compressed |
 | Default format | Full |
+| Default sort | Employee ID (not name) |
+| Yellow highlight | Removed for money columns |
+| Paid For Days Total | Not summed |
+| PDF column widths | Proportional colgroup (not equal) |
+| PDF horizontal rules | Thin dashed in data area |
+| PDF left margin | 18mm for punching/filing |
+| PDF signatures | One equidistant row (table, not flex) |
+| Desk hover | Enabled on data rows |
 
 ## Progress log
 
@@ -104,3 +141,5 @@ Keep Desk report name **Monthly Salary Register Old Format Net Payable** (no new
 |------|------|
 | 2026-08-07 | Spec drafted and saved (planned) |
 | 2026-08-07 | Format filter + compressed layout implemented; tests added |
+| 2026-08-07 | UX polish: no yellow; two-line headers; pin Total; drop Desk SR. NO.; paid days formatting; Employee ID sort; IFSC width; PDF/Excel parity; signatures row; zebra; dashed horizontals; 18mm left margin; Desk hover |
+| 2026-08-07 | Spec reconciled to final Desk/PDF/Excel behaviour; ready for PR |

--- a/specs/005-monthly-salary-register-compressed.md
+++ b/specs/005-monthly-salary-register-compressed.md
@@ -2,8 +2,8 @@
 
 | | |
 |---|---|
-| **Status** | planned |
-| **Branch** | `feat/monthly-salary-register-compressed` (proposed) |
+| **Status** | in progress |
+| **Branch** | `feat/monthly-salary-register-compressed` |
 | **Depends on** | [004 — Monthly Salary Register Old Format](./004-monthly-salary-register.md) |
 | **Surface** | Extend existing Script Report **Monthly Salary Register Old Format Net Payable** |
 | **Primary sources** | Same as 004 (submitted Salary Slip, SSA, Employee bank) |
@@ -103,3 +103,4 @@ Keep Desk report name **Monthly Salary Register Old Format Net Payable** (no new
 | Date | Note |
 |------|------|
 | 2026-08-07 | Spec drafted and saved (planned) |
+| 2026-08-07 | Format filter + compressed layout implemented; tests added |

--- a/specs/005-monthly-salary-register-compressed.md
+++ b/specs/005-monthly-salary-register-compressed.md
@@ -1,0 +1,105 @@
+# 005 — Monthly Salary Register Compressed format
+
+| | |
+|---|---|
+| **Status** | planned |
+| **Branch** | `feat/monthly-salary-register-compressed` (proposed) |
+| **Depends on** | [004 — Monthly Salary Register Old Format](./004-monthly-salary-register.md) |
+| **Surface** | Extend existing Script Report **Monthly Salary Register Old Format Net Payable** |
+| **Primary sources** | Same as 004 (submitted Salary Slip, SSA, Employee bank) |
+
+## Why?
+
+The full old-format register is too wide for everyday review/print. Need a **compressed** view of the same month’s payables with fewer columns, without losing the full layout when ops need component-level detail.
+
+## What?
+
+Add a **Format** filter to the existing report:
+
+| Value | Behavior |
+|-------|----------|
+| `Full` | Current 004 layout (identity + day codes + dynamic ACTUAL/Earning/Deduction comps + net) |
+| `Compressed` | Fixed 10-column layout below |
+
+Filters otherwise unchanged: Company, Year, Month, Population (All/Staff/Worker/Consultant). Inclusion rules same as 004 (submitted slips only, sort by name, exclude holds with no slip).
+
+### Compressed columns (exact)
+
+| # | Column | Source |
+|---|--------|--------|
+| 1 | SR. NO. | Row index (1-based) |
+| 2 | Full Name | Slip `employee_name` / Company Link `full_name` |
+| 3 | IFSC Code | Employee `ifsc_code` |
+| 4 | Account Number | Employee `account_number` |
+| 5 | Days in Month | Calendar days in month |
+| 6 | Paid For Days | Slip `payment_days` |
+| 7 | Actual Gross | Sum of SSA earning amounts (same as Full **Total Gross**) |
+| 8 | Earning Gross | Slip `total_earnings` (same as Full **Total Earning**) |
+| 9 | Deductions | Slip `total_deductions` (employee-share total) |
+| 10 | Net Payable | Slip `net_salary` |
+
+**Dropped vs Full in Compressed:**
+
+- BANK name
+- All day letter-codes (P / R / H / C / T / Y / OD / E / I / A)
+- All per-component ACTUAL / Earning / Deduction columns
+
+### Header / footer / exports
+
+- Header same idea as Full (`Employee Salary Sheet` + period + Month Days)
+- Totals row: sum numeric money/day columns; identity blank or “Total”
+- Signatures: Prepared / Checked / Authorised (same as Full)
+- PDF: A4 landscape; Excel: same columns as Desk for the selected format
+- Highlight Net Payable (and optionally Actual Gross / Earning Gross) in yellow — match Full highlight spirit
+- No ACTUAL/Earning/Deduction color **component bands** in Compressed (no component blocks)
+
+### Desk / PDF / Excel
+
+All three use the Compressed column model when Format = Compressed. Full exports unchanged when Format = Full.
+
+### Default Format
+
+**Full** (preserve existing behaviour for current users).
+
+## How? (implementation sketch)
+
+1. Add `format` filter: `Full` \| `Compressed` (default `Full`)
+2. Reuse `build_register` data pipeline; when Compressed, project each row to the 10 fields above (skip building dynamic component columns)
+3. PDF/Excel builders branch on format (or share a slim table renderer for Compressed)
+4. Tests: Compressed column count/labels; Actual Gross = SSA sum; Earning/Deductions/Net match slip; Full mode regression smoke
+
+### Naming note
+
+Keep Desk report name **Monthly Salary Register Old Format Net Payable** (no new scrub path / no parentheses). Format is a filter only.
+
+## Out of scope
+
+- New standalone report DocType/name
+- Changing Full layout or day-code mapping from 004
+- Per-component breakdown in Compressed
+- BANK name column in Compressed
+
+## Acceptance
+
+1. Format filter Full / Compressed works
+2. Compressed shows exactly the 10 columns listed
+3. Values match Full’s Total Gross / Total Earning / Total Deductions / Net / Paid Days for the same slips
+4. PDF + Excel export Compressed correctly
+5. Full mode behavior unchanged
+
+## Decisions log (grilling)
+
+| Topic | Decision |
+|-------|----------|
+| Surface | Same report + Format filter (`Full` / `Compressed`) |
+| Compressed columns | SR, Full Name, IFSC, Account Number, Days in Month, Paid For Days, Actual Gross, Earning Gross, Deductions, Net Payable |
+| BANK name | Dropped in Compressed |
+| Day codes | Dropped in Compressed |
+| Component columns | Dropped in Compressed |
+| Default format | Full |
+
+## Progress log
+
+| Date | Note |
+|------|------|
+| 2026-08-07 | Spec drafted and saved (planned) |

--- a/specs/PROGRESS.md
+++ b/specs/PROGRESS.md
@@ -7,8 +7,8 @@ Single board for all specs in this folder. New specs get the next number (`002-â
 | 001 | [Company list employee counts](./001-company-list-employee-counts.md) | done | List + form headcount from Company Link; tests passing |
 | 002 | [Maharashtra Professional Tax](./002-maharashtra-professional-tax.md) | in progress | Per-slab Feb amounts; Female no Feb surcharge; multi-state deferred |
 | 003 | [Attendance Dashboard yearly](./003-attendance-dashboard-yearly.md) | done | Merged PR #33 â€” yearly headcount + marking coverage |
-| 004 | [Monthly Salary Register (Old Format)](./004-monthly-salary-register.md) | in progress | Script Report + PDF/Excel; tests passing |
-| 005 | [Monthly Salary Register Compressed](./005-monthly-salary-register-compressed.md) | in progress | Format filter Full/Compressed on existing report |
+| 004 | [Monthly Salary Register (Old Format)](./004-monthly-salary-register.md) | done | Script Report + PDF/Excel; tests passing |
+| 005 | [Monthly Salary Register Compressed](./005-monthly-salary-register-compressed.md) | ready for review | Format filter + Desk/PDF/Excel UX polish |
 
 ## Status legend
 

--- a/specs/PROGRESS.md
+++ b/specs/PROGRESS.md
@@ -8,7 +8,7 @@ Single board for all specs in this folder. New specs get the next number (`002-â
 | 002 | [Maharashtra Professional Tax](./002-maharashtra-professional-tax.md) | in progress | Per-slab Feb amounts; Female no Feb surcharge; multi-state deferred |
 | 003 | [Attendance Dashboard yearly](./003-attendance-dashboard-yearly.md) | done | Merged PR #33 â€” yearly headcount + marking coverage |
 | 004 | [Monthly Salary Register (Old Format)](./004-monthly-salary-register.md) | in progress | Script Report + PDF/Excel; tests passing |
-| 005 | [Monthly Salary Register Compressed](./005-monthly-salary-register-compressed.md) | planned | Format filter Full/Compressed; 10-column slim layout |
+| 005 | [Monthly Salary Register Compressed](./005-monthly-salary-register-compressed.md) | in progress | Format filter Full/Compressed on existing report |
 
 ## Status legend
 

--- a/specs/PROGRESS.md
+++ b/specs/PROGRESS.md
@@ -8,6 +8,7 @@ Single board for all specs in this folder. New specs get the next number (`002-â
 | 002 | [Maharashtra Professional Tax](./002-maharashtra-professional-tax.md) | in progress | Per-slab Feb amounts; Female no Feb surcharge; multi-state deferred |
 | 003 | [Attendance Dashboard yearly](./003-attendance-dashboard-yearly.md) | done | Merged PR #33 â€” yearly headcount + marking coverage |
 | 004 | [Monthly Salary Register (Old Format)](./004-monthly-salary-register.md) | in progress | Script Report + PDF/Excel; tests passing |
+| 005 | [Monthly Salary Register Compressed](./005-monthly-salary-register-compressed.md) | planned | Format filter Full/Compressed; 10-column slim layout |
 
 ## Status legend
 


### PR DESCRIPTION
## Why?

The full old-format salary register is too wide for everyday review. Ops need a compressed monthly payable view without losing the full layout when they need component detail.

## What?

- Format filter on **Monthly Salary Register Old Format Net Payable**: `Full` | `Compressed` (default Full)
- Compressed: 9 data columns (Desk uses built-in serial; PDF/Excel prepend SR. NO.)
- Default sort by Employee ID
- Desk UX: two-line headers, no yellow money highlight, Total pinned on sort, row hover, paid days without trailing `.0`
- PDF/Excel parity: proportional columns, one-row signatures, zebra rows, dashed data horizontals, 18mm left margin for filing

## How?

Extend the existing Script Report pipeline with a Format branch; Desk JS for grid polish; PDF colgroup + border/signature layout; Excel width/align helpers; unit tests for columns, paid-days formatting, sort, and PDF colgroup.

## Test plan

- [ ] Open report → Format Compressed → Fabrixcel / June 2024 (or any month with slips)
- [ ] Confirm 9 data cols + serial; IFSC/Account not clipped; Account left-aligned
- [ ] Sort a money column — Total stays at bottom
- [ ] Paid For Days: wholes without `.0`; Total blank for that column
- [ ] Download PDF — proportional cols, dashed horizontals, zebra, signatures in one row, left punch margin
- [ ] Download Excel — same columns/alignments
- [ ] Format Full still works


Made with [Cursor](https://cursor.com)