### PR TITLE
fix: allow any year on Variable Pay Assignment

### DIFF
--- a/saral_hr/saral_hr/doctype/variable_pay_assignment/variable_pay_assignment.js
+++ b/saral_hr/saral_hr/doctype/variable_pay_assignment/variable_pay_assignment.js
@@ -1,8 +1,15 @@
+const VPA_YEAR_MIN = 1950;
+const VPA_YEAR_MAX = 2099;
+
 frappe.ui.form.on("Variable Pay Assignment", {
     refresh(frm) {
         // Prevent manual add/delete
         frm.set_df_property("variable_pay", "cannot_add_rows", true);
         frm.set_df_property("variable_pay", "cannot_delete_rows", true);
+
+        if (frm.is_new() && !frm.doc.year) {
+            frm.set_value("year", new Date().getFullYear());
+        }
     },
 
     month(frm) {
@@ -12,11 +19,34 @@ frappe.ui.form.on("Variable Pay Assignment", {
     },
 
     year(frm) {
+        normalize_year(frm);
         if (frm.doc.year && frm.doc.month) {
             check_existing_and_load_divisions(frm);
         }
     }
 });
+
+function normalize_year(frm) {
+    if (frm.doc.year === undefined || frm.doc.year === null || frm.doc.year === "") {
+        return;
+    }
+    let year = parseInt(frm.doc.year, 10);
+    if (isNaN(year)) {
+        year = new Date().getFullYear();
+    } else if (year < VPA_YEAR_MIN) {
+        year = VPA_YEAR_MIN;
+    } else if (year > VPA_YEAR_MAX) {
+        year = VPA_YEAR_MAX;
+    }
+    if (cint_or_null(frm.doc.year) !== year) {
+        frm.set_value("year", year);
+    }
+}
+
+function cint_or_null(value) {
+    let n = parseInt(value, 10);
+    return isNaN(n) ? null : n;
+}
 
 function check_existing_and_load_divisions(frm) {
     frappe.call({

--- a/saral_hr/saral_hr/doctype/variable_pay_assignment/variable_pay_assignment.json
+++ b/saral_hr/saral_hr/doctype/variable_pay_assignment/variable_pay_assignment.json
@@ -14,10 +14,10 @@
  "fields": [
   {
    "fieldname": "year",
-   "fieldtype": "Select",
+   "fieldtype": "Int",
    "in_list_view": 1,
    "label": "Year",
-   "options": "\n2025\n2026\n2027\n2028\n2029\n2030",
+   "non_negative": 1,
    "reqd": 1
   },
   {

--- a/saral_hr/saral_hr/doctype/variable_pay_assignment/variable_pay_assignment.py
+++ b/saral_hr/saral_hr/doctype/variable_pay_assignment/variable_pay_assignment.py
@@ -1,11 +1,22 @@
 from frappe.model.document import Document
 import frappe
+from frappe.utils import cint
+
+YEAR_MIN = 1950
+YEAR_MAX = 2099
 
 class VariablePayAssignment(Document):
 
     def validate(self):
+        self.validate_year()
         self.validate_unique_month_year()
         self.validate_duplicate_divisions()
+
+    def validate_year(self):
+        year = cint(self.year)
+        if year < YEAR_MIN or year > YEAR_MAX:
+            frappe.throw(f"Year must be between {YEAR_MIN} and {YEAR_MAX}")
+        self.year = year
 
     def validate_unique_month_year(self):
         """One record per Year + Month"""


### PR DESCRIPTION
## Problem
Variable Pay Assignment year was a Select limited to 2025–2030, so years like 2024 could not be entered.

## Solution
Replace the year dropdown with an Int field (1950–2099), matching Mark Attendance.

Made with [Cursor](https://cursor.com)