### PR TITLE
fix: bulk salary slip left employees and year input

### DIFF
--- a/saral_hr/saral_hr/doctype/salary_slip/salary_slip.py
+++ b/saral_hr/saral_hr/doctype/salary_slip/salary_slip.py
@@ -1263,19 +1263,37 @@ def get_eligible_employees_for_salary_slip(company, year, month, category=None, 
         extra_filters += " AND cl.division = %(division)s"
         filter_params["division"] = division
 
+    # Tenure overlap (not is_active): left employees stay eligible for months
+    # that still fall within date_of_joining..left_date.
+    filter_params["start_date"] = start_date
+    filter_params["end_date"] = str(end_date)
+    tenure_filters = (
+        " AND (cl.date_of_joining IS NULL OR cl.date_of_joining <= %(end_date)s)"
+        " AND (cl.left_date IS NULL OR cl.left_date >= %(start_date)s)"
+    )
+
+    # Active = company headcount for this month (ignores category/division filters).
+    total_active = frappe.db.sql(
+        f"""
+        SELECT COUNT(DISTINCT cl.name) FROM `tabCompany Link` cl
+        WHERE cl.company=%(company)s {tenure_filters}
+        """,
+        {"company": company, "start_date": start_date, "end_date": str(end_date)},
+    )[0][0]
+
     all_emps = frappe.db.sql(f"""
         SELECT DISTINCT cl.name, cl.full_name AS employee_name, cl.department,
             cl.designation, cl.company, cl.division, cl.requires_variable_pay
         FROM `tabCompany Link` cl
-        WHERE cl.is_active=1 AND cl.company=%(company)s {extra_filters}
+        WHERE cl.company=%(company)s {tenure_filters} {extra_filters}
     """, filter_params, as_dict=1)
 
-    with_structure = frappe.db.sql("""
+    with_structure = frappe.db.sql(f"""
         SELECT DISTINCT cl.name FROM `tabCompany Link` cl
         INNER JOIN `tabSalary Structure Assignment` ssa ON ssa.employee=cl.name
-        WHERE cl.is_active=1 AND cl.company=%(company)s AND ssa.docstatus=1
+        WHERE cl.company=%(company)s {tenure_filters} AND ssa.docstatus=1
           AND ssa.from_date<=%(start_date)s AND (ssa.to_date IS NULL OR ssa.to_date>=%(end_date)s)
-    """, {"company": company, "start_date": start_date, "end_date": str(end_date)}, as_dict=1)
+    """, filter_params, as_dict=1)
     with_structure_ids = {e.name for e in with_structure}
 
     emp_names = [e.name for e in all_emps]
@@ -1340,7 +1358,7 @@ def get_eligible_employees_for_salary_slip(company, year, month, category=None, 
         "eligible":                       eligible,
         "skipped":                        ineligible,
         "already_generated":              already_generated,
-        "total_active":                   len(all_emps),
+        "total_active":                   total_active,
         "total_eligible":                 len(eligible),
         "category_requires_variable_pay": cat_requires_vpa,
     }
@@ -1552,9 +1570,21 @@ def get_salary_slips_print_summary(company, year, month, category=None, division
         extra_filters += " AND division=%(division)s"
         filter_params["division"] = division
 
+    end_date = get_last_day(getdate(start_date))
+    filter_params["start_date"] = start_date
+    filter_params["end_date"] = str(end_date)
+    tenure_filters = (
+        " AND (date_of_joining IS NULL OR date_of_joining <= %(end_date)s)"
+        " AND (left_date IS NULL OR left_date >= %(start_date)s)"
+    )
+    total_active = frappe.db.sql(
+        f"SELECT COUNT(*) FROM `tabCompany Link` "
+        f"WHERE company=%(company)s {tenure_filters}",
+        {"company": company, "start_date": start_date, "end_date": str(end_date)},
+    )[0][0]
     all_emps = frappe.db.sql(
         f"SELECT name, full_name AS employee_name FROM `tabCompany Link` "
-        f"WHERE is_active=1 AND company=%(company)s {extra_filters}",
+        f"WHERE company=%(company)s {tenure_filters} {extra_filters}",
         filter_params, as_dict=1
     )
 
@@ -1589,6 +1619,6 @@ def get_salary_slips_print_summary(company, year, month, category=None, division
     return {
         'submitted':       submitted,
         'not_printable':   not_printable,
-        'total_active':    len(all_emps),
+        'total_active':    total_active,
         'total_submitted': len(submitted)
     }

--- a/saral_hr/saral_hr/doctype/salary_slip/salary_slip_list.js
+++ b/saral_hr/saral_hr/doctype/salary_slip/salary_slip_list.js
@@ -13,9 +13,35 @@ frappe.listview_settings['Salary Slip'] = {
 const MONTHS = ['January','February','March','April','May','June',
                 'July','August','September','October','November','December'];
 
-function get_year_options() { const y = new Date().getFullYear(); return [y-2, y-1, y, y+1].map(String); }
+const SS_YEAR_MIN = 1950;
+const SS_YEAR_MAX = 2099;
+
 function get_current_month() { return MONTHS[new Date().getMonth()]; }
-function get_current_year()  { return new Date().getFullYear().toString(); }
+function get_current_year()  { return new Date().getFullYear(); }
+
+function clamp_year(value) {
+    let year = parseInt(value, 10);
+    if (isNaN(year)) return get_current_year();
+    if (year < SS_YEAR_MIN) return SS_YEAR_MIN;
+    if (year > SS_YEAR_MAX) return SS_YEAR_MAX;
+    return year;
+}
+
+function bind_year_clamp(dialog) {
+    const field = dialog.fields_dict.year;
+    if (!field || !field.$input) return;
+    field.$input.attr({ min: SS_YEAR_MIN, max: SS_YEAR_MAX, step: 1 });
+    field.$input.on('change blur', () => {
+        const clamped = clamp_year(dialog.get_value('year'));
+        if (parseInt(dialog.get_value('year'), 10) !== clamped) {
+            dialog.set_value('year', clamped);
+        }
+    });
+}
+
+function year_field() {
+    return { fieldname:'year', fieldtype:'Int', label:'Year', reqd:1, default:get_current_year() };
+}
 
 // ─── Shared icon helpers ──────────────────────────────────────────────────────
 
@@ -357,7 +383,7 @@ function show_bulk_salary_slip_dialog() {
         title: __('Bulk Generate Salary Slips'),
         size:  'large',
         fields: [
-            { fieldname:'year',       fieldtype:'Select', label:'Year',    options:get_year_options(), reqd:1, default:get_current_year() },
+            year_field(),
             { fieldname:'cb1',        fieldtype:'Column Break' },
             { fieldname:'month',      fieldtype:'Select', label:'Month',   options:MONTHS, reqd:1, default:get_current_month() },
             { fieldname:'cb2',        fieldtype:'Column Break' },
@@ -378,14 +404,18 @@ function show_bulk_salary_slip_dialog() {
         primary_action: () => generate_bulk_salary_slips(d)
     });
     d.show();
+    bind_year_clamp(d);
 }
 
 function fetch_generate_employees(dialog) {
-    const { company, year, month, category, division } =
+    let { company, year, month, category, division } =
         _get_dialog_values(dialog, ['company','year','month','category','division']);
 
     if (!company)        { frappe.msgprint(__('Please select Company'));        return; }
     if (!year || !month) { frappe.msgprint(__('Please select Year and Month')); return; }
+
+    year = clamp_year(year);
+    dialog.set_value('year', year);
 
     const wrapper = dialog.fields_dict.emp_html.$wrapper;
     wrapper.html(_loading_html('Retrieving employee payroll eligibility…'));
@@ -408,10 +438,9 @@ function fetch_generate_employees(dialog) {
                 category_requires_variable_pay
             } = r.message;
 
-            const filter_label = [category, division].filter(Boolean).join(' / ') || 'All';
             wrapper.html(
                 _summary_bar([
-                    [`Active (${frappe.utils.escape_html(filter_label)})`, total_active],
+                    ['Active', total_active],
                     ['Eligible',          total_eligible],
                     ['Already Generated', already_generated.length],
                     ['Not Eligible',      skipped.length]
@@ -475,7 +504,7 @@ function generate_bulk_salary_slips(dialog) {
                     method: 'saral_hr.saral_hr.doctype.salary_slip.salary_slip.bulk_generate_salary_slips',
                     args: {
                         employees: [{ employee: emp.id, employee_name: emp.name }],
-                        year:   dialog.get_value('year'),
+                        year:   clamp_year(dialog.get_value('year')),
                         month:  dialog.get_value('month')
                     },
                     callback(r) { process_next(idx + 1); },
@@ -495,7 +524,7 @@ function show_bulk_print_dialog() {
         title: __('Bulk Print Salary Slips'),
         size:  'large',
         fields: [
-            { fieldname:'year',       fieldtype:'Select', label:'Year',    options:get_year_options(), reqd:1, default:get_current_year() },
+            year_field(),
             { fieldname:'cb1',        fieldtype:'Column Break' },
             { fieldname:'month',      fieldtype:'Select', label:'Month',   options:MONTHS, reqd:1, default:get_current_month() },
             { fieldname:'cb2',        fieldtype:'Column Break' },
@@ -516,14 +545,18 @@ function show_bulk_print_dialog() {
         primary_action: () => print_selected_salary_slips(d)
     });
     d.show();
+    bind_year_clamp(d);
 }
 
 function fetch_print_slips(dialog) {
-    const { company, year, month, category, division } =
+    let { company, year, month, category, division } =
         _get_dialog_values(dialog, ['company','year','month','category','division']);
 
     if (!company)        { frappe.msgprint(__('Please select Company'));        return; }
     if (!year || !month) { frappe.msgprint(__('Please select Year and Month')); return; }
+
+    year = clamp_year(year);
+    dialog.set_value('year', year);
 
     const wrapper = dialog.fields_dict.slip_html.$wrapper;
     wrapper.html(_loading_html('Retrieving submitted salary slips…'));
@@ -560,10 +593,9 @@ function fetch_print_slips(dialog) {
                 }))
             ];
 
-            const filter_label = [category, division].filter(Boolean).join(' / ') || 'All';
             wrapper.html(
                 _summary_bar([
-                    [`Active (${frappe.utils.escape_html(filter_label)})`, total_active],
+                    ['Active', total_active],
                     ['Submitted Slips', total_submitted],
                     ['Cannot Print',    not_printable.length]
                 ]) + '<div id="print_tbl"></div>'
@@ -640,7 +672,7 @@ function show_draft_to_submit_dialog() {
     const d = new frappe.ui.Dialog({
         title: __('Submit Draft Salary Slips'),
         fields: [
-            { fieldname:'year',         fieldtype:'Select', label:'Year',    options:get_year_options(), reqd:1, default:get_current_year() },
+            year_field(),
             { fieldname:'cb1',          fieldtype:'Column Break' },
             { fieldname:'month',        fieldtype:'Select', label:'Month',   options:MONTHS, reqd:1, default:get_current_month() },
             { fieldname:'cb2',          fieldtype:'Column Break' },
@@ -655,12 +687,15 @@ function show_draft_to_submit_dialog() {
         primary_action: () => submit_selected_salary_slips(d)
     });
     d.show();
+    bind_year_clamp(d);
 }
 
 function fetch_draft_salary_slips(dialog) {
-    const { company, year, month } = _get_dialog_values(dialog, ['company','year','month']);
+    let { company, year, month } = _get_dialog_values(dialog, ['company','year','month']);
     if (!company)        { frappe.msgprint(__('Please select Company'));        return; }
     if (!year || !month) { frappe.msgprint(__('Please select Year and Month')); return; }
+    year = clamp_year(year);
+    dialog.set_value('year', year);
     frappe.call({
         method: 'saral_hr.saral_hr.doctype.salary_slip.salary_slip.get_draft_salary_slips',
         args: { company, year, month },

--- a/saral_hr/saral_hr/doctype/salary_slip/test_salary_slip.py
+++ b/saral_hr/saral_hr/doctype/salary_slip/test_salary_slip.py
@@ -8,6 +8,7 @@ from frappe.utils import add_days, get_first_day, get_last_day, getdate
 from saral_hr.saral_hr.doctype.salary_slip.salary_slip import (
 	calculate_salary_slip_amounts_exact,
 	get_attendance_and_days,
+	get_eligible_employees_for_salary_slip,
 	get_salary_amount_rounding_digits,
 	round_salary_amount,
 )
@@ -164,3 +165,31 @@ class TestSalaryAmountRounding(FrappeTestCase):
 		frappe.db.set_value("Company", company, "salary_amount_rounding_digits", "2")
 		calculate_salary_slip_amounts_exact(ss, 0, "2024-01-01")
 		self.assertEqual(ss.earnings[0].amount, 3333.33)
+
+
+def _ids_from_eligible_result(result):
+	ids = {row.get("name") for row in result.get("eligible") or []}
+	for bucket in ("skipped", "already_generated"):
+		for row in result.get(bucket) or []:
+			ids.add(row.get("id"))
+	return ids
+
+
+class TestBulkEligibleLeftEmployees(FrappeTestCase):
+	def test_left_employee_included_only_for_overlapping_months(self):
+		"""Left employees must appear for months within tenure, not after left_date."""
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-01-01", weekly_off="")
+		doc = frappe.get_doc("Company Link", cl)
+		doc.left_date = getdate("2024-03-15")
+		doc.save(ignore_permissions=True)
+		self.assertEqual(frappe.db.get_value("Company Link", cl, "is_active"), 0)
+
+		march = get_eligible_employees_for_salary_slip(company, "2024", "March")
+		self.assertIn(cl, _ids_from_eligible_result(march))
+		self.assertEqual(march["total_active"], 1)
+
+		april = get_eligible_employees_for_salary_slip(company, "2024", "April")
+		self.assertNotIn(cl, _ids_from_eligible_result(april))
+		self.assertEqual(april["total_active"], 0)


### PR DESCRIPTION
## Problem
Bulk salary slip Get Employees skipped people marked as left even when the payroll month still overlapped their service, Active counted the wrong set, and year was a short Select list.

## Solution
- Filter employees by joining/left dates for the selected month instead of `is_active`
- Count Active as company headcount for that month
- Use Int year (1950–2099) like Mark Attendance
- Cover left-employee tenure with a unit test

Made with [Cursor](https://cursor.com)