### PR TITLE
feat: Data Cleansing for attendance and salary slip audit

### DIFF
--- a/saral_hr/saral_hr/doctype/data_cleansing_log/__init__.py
+++ b/saral_hr/saral_hr/doctype/data_cleansing_log/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, sj and contributors
+# For license information, please see license.txt

--- a/saral_hr/saral_hr/doctype/data_cleansing_log/data_cleansing_log.json
+++ b/saral_hr/saral_hr/doctype/data_cleansing_log/data_cleansing_log.json
@@ -1,0 +1,146 @@
+{
+ "actions": [],
+ "allow_copy": 0,
+ "allow_import": 0,
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-08-08 10:45:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "employee",
+  "employee_name",
+  "company",
+  "column_break_1",
+  "month_start",
+  "action",
+  "counts",
+  "section_details",
+  "reference_names",
+  "reason"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Employee",
+   "options": "Company Link",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fetch_from": "employee.full_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Employee Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Company",
+   "options": "Company",
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "month_start",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Month Start",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "action",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Action",
+   "options": "delete_attendance\ncancel_salary_slip\ndelete_salary_slip",
+   "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "counts",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Counts"
+  },
+  {
+   "fieldname": "section_details",
+   "fieldtype": "Section Break",
+   "label": "Details"
+  },
+  {
+   "fieldname": "reference_names",
+   "fieldtype": "Small Text",
+   "label": "Reference Names"
+  },
+  {
+   "fieldname": "reason",
+   "fieldtype": "Small Text",
+   "label": "Reason"
+  }
+ ],
+ "in_create": 0,
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-08-08 10:45:00.000000",
+ "modified_by": "Administrator",
+ "module": "Saral Hr",
+ "name": "Data Cleansing Log",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Saral HR Manager",
+   "share": 0,
+   "write": 0
+  },
+  {
+   "create": 0,
+   "delete": 0,
+   "email": 0,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Saral HR User",
+   "share": 0,
+   "write": 0
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/saral_hr/saral_hr/doctype/data_cleansing_log/data_cleansing_log.py
+++ b/saral_hr/saral_hr/doctype/data_cleansing_log/data_cleansing_log.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, sj and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class DataCleansingLog(Document):
+	pass

--- a/saral_hr/saral_hr/page/data_cleansing/__init__.py
+++ b/saral_hr/saral_hr/page/data_cleansing/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, sj and contributors
+# For license information, please see license.txt

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
@@ -1,17 +1,350 @@
 frappe.pages["data-cleansing"].on_page_load = function (wrapper) {
-	frappe.ui.make_app_page({
+	const page = frappe.ui.make_app_page({
 		parent: wrapper,
 		title: __("Data Cleansing"),
 		single_column: true,
 	});
+	wrapper._dc_page = page;
 };
 
 frappe.pages["data-cleansing"].on_page_show = function (wrapper) {
+	inject_dc_styles();
 	const $main = $(wrapper).find(".layout-main-section");
-	$main.html(`
-		<div class="text-muted" style="padding: 1.5rem;">
-			<p>${__("Employee attendance & salary audit / cleanse.")}</p>
-			<p>${__("Implementation in progress — see specs/007-data-cleansing.md.")}</p>
+	$main.html(dc_shell_html());
+	init_data_cleansing($main, wrapper._dc_page);
+};
+
+function inject_dc_styles() {
+	if (document.getElementById("dc-styles")) return;
+	const s = document.createElement("style");
+	s.id = "dc-styles";
+	s.innerHTML = `
+		.dc-root { padding: 0 20px 40px; font-family: var(--font-stack); color: var(--text-color); }
+		.dc-filter-bar { display: flex; align-items: flex-end; gap: 12px; flex-wrap: wrap; padding: 16px 0 12px; }
+		.dc-field { display: flex; flex-direction: column; gap: 4px; min-width: 140px; }
+		.dc-field label { font-size: 11px; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
+		.dc-field .frappe-control { margin-bottom: 0 !important; }
+		.dc-btn {
+			height: 30px; padding: 0 14px; background: var(--primary); color: #fff;
+			border: none; border-radius: var(--border-radius); font-size: 12px; font-weight: 600; cursor: pointer;
+		}
+		.dc-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+		.dc-btn-outline {
+			height: 28px; padding: 0 10px; background: transparent; color: var(--text-color);
+			border: 1px solid var(--border-color); border-radius: var(--border-radius); font-size: 12px; cursor: pointer;
+		}
+		.dc-btn-danger { background: var(--red-500, #e03131); color: #fff; border: none; }
+		.dc-meta { font-size: 13px; color: var(--text-muted); margin-bottom: 12px; }
+		.dc-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+		.dc-table th, .dc-table td { border-bottom: 1px solid var(--border-color); padding: 8px 10px; text-align: left; vertical-align: top; }
+		.dc-table th { font-size: 11px; text-transform: uppercase; color: var(--text-muted); font-weight: 600; }
+		.dc-table tr:hover td { background: var(--fg-hover, rgba(0,0,0,0.02)); }
+		.dc-flag {
+			display: inline-block; margin: 1px 4px 1px 0; padding: 1px 7px; border-radius: 10px;
+			font-size: 11px; background: var(--bg-light-gray, #f1f3f5); color: var(--text-color);
+		}
+		.dc-flag.warn { background: #fff3bf; color: #5c4800; }
+		.dc-flag.bad { background: #ffe3e3; color: #c92a2a; }
+		.dc-empty { padding: 24px 0; color: var(--text-muted); }
+		.dc-detail { margin-top: 20px; border: 1px solid var(--border-color); border-radius: 8px; padding: 14px 16px; }
+		.dc-detail h4 { margin: 0 0 10px; font-size: 14px; }
+		.dc-detail-actions { display: flex; gap: 8px; flex-wrap: wrap; margin: 10px 0 14px; }
+		.dc-att-list { max-height: 280px; overflow: auto; border: 1px solid var(--border-color); border-radius: 6px; }
+		.dc-att-row { display: flex; align-items: center; gap: 10px; padding: 6px 10px; border-bottom: 1px solid var(--border-color); font-size: 13px; }
+		.dc-att-row:last-child { border-bottom: none; }
+		.dc-slip-row { display: flex; align-items: center; gap: 10px; padding: 8px 0; border-bottom: 1px solid var(--border-color); font-size: 13px; }
+	`;
+	document.head.appendChild(s);
+}
+
+function dc_shell_html() {
+	return `
+		<div class="dc-root">
+			<div class="dc-filter-bar">
+				<div class="dc-field" style="min-width:260px"><label>${__("Employee")}</label><div class="dc-employee"></div></div>
+				<div class="dc-field"><label>${__("From Year")}</label><input type="number" class="form-control dc-from-year" min="1950" max="2099"></div>
+				<div class="dc-field"><label>${__("From Month")}</label><select class="form-control dc-from-month"></select></div>
+				<div class="dc-field"><label>${__("To Year")}</label><input type="number" class="form-control dc-to-year" min="1950" max="2099"></div>
+				<div class="dc-field"><label>${__("To Month")}</label><select class="form-control dc-to-month"></select></div>
+				<button class="dc-btn dc-load">${__("Load")}</button>
+			</div>
+			<div class="dc-meta"></div>
+			<div class="dc-matrix"></div>
+			<div class="dc-detail-wrap"></div>
+		</div>
+	`;
+}
+
+const DC_MONTHS = [
+	"January","February","March","April","May","June",
+	"July","August","September","October","November","December"
+];
+
+function init_data_cleansing($main) {
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = now.getMonth() + 1;
+
+	const $fromMonth = $main.find(".dc-from-month");
+	const $toMonth = $main.find(".dc-to-month");
+	DC_MONTHS.forEach((label, i) => {
+		$fromMonth.append(`<option value="${i + 1}">${label}</option>`);
+		$toMonth.append(`<option value="${i + 1}">${label}</option>`);
+	});
+	$main.find(".dc-from-year").val(year);
+	$main.find(".dc-to-year").val(year);
+	$fromMonth.val(1);
+	$toMonth.val(month);
+
+	const employee_control = frappe.ui.form.make_control({
+		parent: $main.find(".dc-employee"),
+		df: {
+			fieldtype: "Link",
+			options: "Company Link",
+			fieldname: "employee",
+			placeholder: __("Select Company Link"),
+			only_select: 1,
+		},
+		render_input: true,
+	});
+	employee_control.refresh();
+
+	const state = {
+		employee_control,
+		matrix: null,
+		detail: null,
+		can_mutate: false,
+	};
+
+	$main.find(".dc-load").on("click", () => load_matrix($main, state));
+}
+
+function load_matrix($main, state, after) {
+	const employee = state.employee_control.get_value();
+	if (!employee) {
+		frappe.msgprint(__("Please select an employee"));
+		return;
+	}
+	const args = {
+		employee,
+		from_year: cint($main.find(".dc-from-year").val()),
+		from_month: cint($main.find(".dc-from-month").val()),
+		to_year: cint($main.find(".dc-to-year").val()),
+		to_month: cint($main.find(".dc-to-month").val()),
+	};
+
+	$main.find(".dc-matrix").html(`<div class="dc-empty">${__("Loading…")}</div>`);
+	if (!after) $main.find(".dc-detail-wrap").empty();
+
+	frappe.call({
+		method: "saral_hr.saral_hr.page.data_cleansing.data_cleansing.get_employee_month_matrix",
+		args,
+		callback(r) {
+			state.matrix = r.message || {};
+			state.can_mutate = !!state.matrix.can_mutate;
+			render_matrix($main, state);
+			if (typeof after === "function") after();
+		},
+	});
+}
+
+function flag_class(flag) {
+	if (flag === "Partial coverage" || flag === "Draft slip") return "warn";
+	return "bad";
+}
+
+function render_matrix($main, state) {
+	const m = state.matrix;
+	const tenure = [
+		m.date_of_joining ? `${__("Joined")} ${frappe.datetime.str_to_user(m.date_of_joining)}` : null,
+		m.left_date ? `${__("Left")} ${frappe.datetime.str_to_user(m.left_date)}` : null,
+	].filter(Boolean).join(" · ");
+
+	$main.find(".dc-meta").html(
+		`<strong>${frappe.utils.escape_html(m.employee_name || m.employee)}</strong>`
+		+ ` · ${frappe.utils.escape_html(m.company || "")}`
+		+ (tenure ? ` · ${tenure}` : "")
+		+ (state.can_mutate ? "" : ` · <span class="text-muted">${__("View only")}</span>`)
+	);
+
+	const rows = m.months || [];
+	if (!rows.length) {
+		$main.find(".dc-matrix").html(`<div class="dc-empty">${__("No attendance or salary slips in this range.")}</div>`);
+		return;
+	}
+
+	let html = `<table class="dc-table"><thead><tr>
+		<th>${__("Month")}</th><th>${__("Att days")}</th><th>${__("Expected")}</th>
+		<th>${__("Coverage")}</th><th>${__("Slip")}</th><th>${__("Slip status")}</th>
+		<th>${__("Flags")}</th><th></th>
+	</tr></thead><tbody>`;
+
+	rows.forEach((row) => {
+		const flags = (row.flags || []).map(
+			(f) => `<span class="dc-flag ${flag_class(f)}">${frappe.utils.escape_html(f)}</span>`
+		).join("");
+		html += `<tr data-year="${row.year}" data-month="${row.month}">
+			<td>${frappe.utils.escape_html(row.month_label)}</td>
+			<td>${row.attendance_days}</td>
+			<td>${row.expected_days}</td>
+			<td>${frappe.utils.escape_html(row.coverage)}</td>
+			<td>${frappe.utils.escape_html(row.slip_names)}</td>
+			<td>${frappe.utils.escape_html(row.slip_status)}</td>
+			<td>${flags || "—"}</td>
+			<td><button class="dc-btn-outline dc-view">${__("View")}</button></td>
+		</tr>`;
+	});
+	html += "</tbody></table>";
+	$main.find(".dc-matrix").html(html);
+
+	$main.find(".dc-matrix .dc-view").on("click", function () {
+		const $tr = $(this).closest("tr");
+		load_detail($main, state, cint($tr.data("year")), cint($tr.data("month")));
+	});
+}
+
+function load_detail($main, state, year, month) {
+	frappe.call({
+		method: "saral_hr.saral_hr.page.data_cleansing.data_cleansing.get_month_detail",
+		args: { employee: state.matrix.employee, year, month },
+		callback(r) {
+			state.detail = r.message;
+			render_detail($main, state);
+		},
+	});
+}
+
+function render_detail($main, state) {
+	const d = state.detail;
+	if (!d) return;
+	const can = state.can_mutate;
+	const summary = d.summary || {};
+	const label = summary.month_label || `${d.month_start}`;
+
+	let actions = "";
+	if (can) {
+		if ((d.slips || []).length) {
+			actions += `<span class="text-muted" style="font-size:12px">${__("Delete attendance is blocked until all slips for this month are removed.")}</span>`;
+		} else if ((d.attendance || []).length) {
+			actions += `<button class="dc-btn dc-btn-danger dc-del-month">${__("Delete all attendance this month")}</button>`;
+			actions += `<button class="dc-btn-outline dc-del-selected">${__("Delete selected days")}</button>`;
+		}
+	}
+
+	let slips_html = "";
+	(d.slips || []).forEach((s) => {
+		let btns = `<a href="/app/salary-slip/${encodeURIComponent(s.name)}" target="_blank">${frappe.utils.escape_html(s.name)}</a>`;
+		btns += ` · ${frappe.utils.escape_html(s.status)}`;
+		if (can && s.docstatus === 1) {
+			btns += ` <button class="dc-btn-outline dc-cancel-slip" data-name="${frappe.utils.escape_html(s.name)}">${__("Cancel")}</button>`;
+		}
+		if (can && s.docstatus !== 1) {
+			btns += ` <button class="dc-btn-outline dc-del-slip" data-name="${frappe.utils.escape_html(s.name)}">${__("Delete")}</button>`;
+		}
+		slips_html += `<div class="dc-slip-row">${btns}</div>`;
+	});
+	if (!slips_html) slips_html = `<div class="text-muted">${__("No salary slips")}</div>`;
+
+	let att_html = "";
+	(d.attendance || []).forEach((a) => {
+		const cb = can && !(d.slips || []).length
+			? `<input type="checkbox" class="dc-att-cb" value="${frappe.utils.escape_html(a.name)}">`
+			: "";
+		att_html += `<div class="dc-att-row">${cb}
+			<span style="width:110px">${frappe.datetime.str_to_user(a.attendance_date)}</span>
+			<span>${frappe.utils.escape_html(a.status)}</span>
+			<a class="text-muted" href="/app/attendance/${encodeURIComponent(a.name)}" target="_blank">${frappe.utils.escape_html(a.name)}</a>
+		</div>`;
+	});
+	if (!att_html) att_html = `<div class="dc-empty">${__("No attendance rows")}</div>`;
+
+	$main.find(".dc-detail-wrap").html(`
+		<div class="dc-detail">
+			<h4>${__("Detail")} — ${frappe.utils.escape_html(label)}</h4>
+			<div class="dc-detail-actions">${actions}</div>
+			<div style="margin-bottom:8px;font-weight:600">${__("Salary Slips")}</div>
+			${slips_html}
+			<div style="margin:14px 0 8px;font-weight:600">${__("Attendance")} (${(d.attendance || []).length})</div>
+			<div class="dc-att-list">${att_html}</div>
 		</div>
 	`);
-};
+
+	$main.find(".dc-cancel-slip").on("click", function () {
+		const name = $(this).data("name");
+		frappe.confirm(__("Cancel salary slip {0}?", [name]), () => {
+			frappe.call({
+				method: "saral_hr.saral_hr.page.data_cleansing.data_cleansing.cancel_salary_slip",
+				args: { name },
+				callback() {
+					frappe.show_alert({ message: __("Cancelled"), indicator: "green" });
+					reload_after_mutate($main, state, summary.year, summary.month);
+				},
+			});
+		});
+	});
+
+	$main.find(".dc-del-slip").on("click", function () {
+		const name = $(this).data("name");
+		frappe.confirm(__("Delete salary slip {0}? This cannot be undone.", [name]), () => {
+			frappe.call({
+				method: "saral_hr.saral_hr.page.data_cleansing.data_cleansing.delete_salary_slip",
+				args: { name },
+				callback() {
+					frappe.show_alert({ message: __("Deleted"), indicator: "green" });
+					reload_after_mutate($main, state, summary.year, summary.month);
+				},
+			});
+		});
+	});
+
+	$main.find(".dc-del-month").on("click", () => {
+		const n = (d.attendance || []).length;
+		frappe.confirm(
+			__("Delete {0} attendance row(s) for {1}?", [n, label]),
+			() => {
+				frappe.call({
+					method: "saral_hr.saral_hr.page.data_cleansing.data_cleansing.delete_attendance",
+					args: {
+						employee: state.matrix.employee,
+						year: summary.year,
+						month: summary.month,
+					},
+					callback(r) {
+						frappe.show_alert({
+							message: __("Deleted {0} attendance row(s)", [r.message.count]),
+							indicator: "green",
+						});
+						reload_after_mutate($main, state, summary.year, summary.month);
+					},
+				});
+			}
+		);
+	});
+
+	$main.find(".dc-del-selected").on("click", () => {
+		const names = $main.find(".dc-att-cb:checked").map(function () { return this.value; }).get();
+		if (!names.length) {
+			frappe.msgprint(__("Select at least one day"));
+			return;
+		}
+		frappe.confirm(__("Delete {0} selected attendance day(s)?", [names.length]), () => {
+			frappe.call({
+				method: "saral_hr.saral_hr.page.data_cleansing.data_cleansing.delete_attendance",
+				args: { employee: state.matrix.employee, names },
+				callback(r) {
+					frappe.show_alert({
+						message: __("Deleted {0} attendance row(s)", [r.message.count]),
+						indicator: "green",
+					});
+					reload_after_mutate($main, state, summary.year, summary.month);
+				},
+			});
+		});
+	});
+}
+
+function reload_after_mutate($main, state, year, month) {
+	load_matrix($main, state, () => {
+		if (year && month) load_detail($main, state, year, month);
+	});
+}

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
@@ -31,9 +31,9 @@ function dc_set_breadcrumbs() {
 }
 
 function inject_dc_styles() {
-	$("#dc-styles, #dc-styles-v2, #dc-styles-v3, #dc-styles-v4, #dc-styles-v5").remove();
+	$("#dc-styles, #dc-styles-v2, #dc-styles-v3, #dc-styles-v4, #dc-styles-v5, #dc-styles-v6").remove();
 	const s = document.createElement("style");
-	s.id = "dc-styles-v5";
+	s.id = "dc-styles-v6";
 	s.innerHTML = `
 		.dc-root { padding: 8px 0 40px; color: var(--text-color); }
 		.dc-filter-card, .dc-emp-card, .dc-results-card {
@@ -43,42 +43,53 @@ function inject_dc_styles() {
 			margin-bottom: 12px;
 		}
 		.dc-filter-card { padding: 14px 16px; }
-		.dc-filter-grid {
-			display: grid;
-			grid-template-columns: minmax(220px, 1.1fr) max-content repeat(4, 108px) auto;
-			column-gap: 12px;
-			row-gap: 6px;
-			align-items: center;
+		.dc-filter-row {
+			display: flex;
+			flex-wrap: wrap;
+			align-items: flex-end;
+			gap: 12px 14px;
 		}
-		.dc-filter-grid > .dc-filter-label {
-			grid-row: 1;
+		.dc-fg {
+			display: flex;
+			flex-direction: column;
+			gap: 5px;
+			min-width: 0;
+		}
+		.dc-fg-employee { flex: 1 1 240px; min-width: 200px; max-width: 320px; }
+		.dc-fg-mode { flex: 0 1 auto; }
+		.dc-fg-period { flex: 0 0 108px; width: 108px; }
+		.dc-fg-action { flex: 0 0 auto; }
+		.dc-fg-label {
 			font-size: 11px; font-weight: 700; color: var(--text-muted);
 			text-transform: uppercase; letter-spacing: .04em; margin: 0; line-height: 1.2;
+			min-height: 14px;
 		}
-		.dc-filter-grid > .dc-filter-control { grid-row: 2; min-width: 0; }
 		.dc-employee-wrap .frappe-control,
 		.dc-employee-wrap .form-group { margin-bottom: 0 !important; }
 		.dc-employee-wrap .control-label,
 		.dc-employee-wrap .help-box,
-		.dc-employee-wrap .clearfix { display: none !important; height: 0 !important; margin: 0 !important; padding: 0 !important; }
+		.dc-employee-wrap .clearfix {
+			display: none !important; height: 0 !important; margin: 0 !important; padding: 0 !important;
+		}
 		.dc-employee-wrap .control-input-wrapper,
 		.dc-employee-wrap .awesomplete,
 		.dc-employee-wrap .awesomplete > input { width: 100% !important; }
 		.dc-employee-wrap input.input-with-feedback,
-		.dc-filter-grid .form-control,
-		.dc-filter-grid select,
-		.dc-filter-grid input[type=number] {
+		.dc-fg .form-control,
+		.dc-fg select,
+		.dc-fg input[type=number] {
 			height: 32px !important; min-height: 32px !important;
 			font-size: 13px; border-radius: 6px; margin: 0; width: 100%;
 		}
-		.dc-period-fields.dc-disabled,
 		.dc-period-disabled { opacity: .4; pointer-events: none; }
-		@media (max-width: 1100px) {
-			.dc-filter-grid {
-				grid-template-columns: repeat(2, minmax(160px, 1fr));
+		@media (max-width: 720px) {
+			.dc-filter-row { flex-direction: column; align-items: stretch; }
+			.dc-fg-employee, .dc-fg-mode, .dc-fg-period, .dc-fg-action {
+				flex: 1 1 auto; width: 100%; max-width: none;
 			}
-			.dc-filter-grid > .dc-filter-label,
-			.dc-filter-grid > .dc-filter-control { grid-row: auto; }
+			.dc-mode-toggle { width: 100%; }
+			.dc-mode-toggle button { flex: 1; }
+			.dc-fg-action .dc-btn { width: 100%; }
 		}
 		.dc-mode-toggle {
 			display: inline-flex; border: 1px solid var(--border-color); border-radius: 6px;
@@ -92,7 +103,6 @@ function inject_dc_styles() {
 			background: var(--fg-color); color: var(--text-color);
 			box-shadow: inset 0 0 0 1px var(--border-color);
 		}
-		.dc-period-fields.dc-disabled { opacity: .4; pointer-events: none; }
 		.dc-btn {
 			height: 32px; padding: 0 18px; border: none; border-radius: 6px;
 			background: var(--primary); color: #fff; font-size: 13px; font-weight: 600; cursor: pointer;
@@ -210,27 +220,38 @@ function dc_shell_html() {
 	return `
 		<div class="dc-root">
 			<div class="dc-filter-card">
-				<div class="dc-filter-grid">
-					<div class="dc-filter-label">${__("Employee")}</div>
-					<div class="dc-filter-label">${__("Scan mode")}</div>
-					<div class="dc-filter-label dc-period-label">${__("From Year")}</div>
-					<div class="dc-filter-label dc-period-label">${__("From Month")}</div>
-					<div class="dc-filter-label dc-period-label">${__("To Year")}</div>
-					<div class="dc-filter-label dc-period-label">${__("To Month")}</div>
-					<div class="dc-filter-label">&nbsp;</div>
-
-					<div class="dc-filter-control dc-employee-wrap"><div class="dc-employee"></div></div>
-					<div class="dc-filter-control">
+				<div class="dc-filter-row">
+					<div class="dc-fg dc-fg-employee">
+						<div class="dc-fg-label">${__("Employee")}</div>
+						<div class="dc-employee-wrap"><div class="dc-employee"></div></div>
+					</div>
+					<div class="dc-fg dc-fg-mode">
+						<div class="dc-fg-label">${__("Scan mode")}</div>
 						<div class="dc-mode-toggle" title="${__("Period scan uses From–To. Whole data search lists every month with attendance or slips.")}">
 							<button type="button" class="dc-mode-btn" data-mode="period">${__("Period scan")}</button>
 							<button type="button" class="dc-mode-btn active" data-mode="all">${__("Whole data search")}</button>
 						</div>
 					</div>
-					<div class="dc-filter-control dc-period-field"><input type="number" class="form-control dc-from-year" min="1950" max="2099"></div>
-					<div class="dc-filter-control dc-period-field"><select class="form-control dc-from-month"></select></div>
-					<div class="dc-filter-control dc-period-field"><input type="number" class="form-control dc-to-year" min="1950" max="2099"></div>
-					<div class="dc-filter-control dc-period-field"><select class="form-control dc-to-month"></select></div>
-					<div class="dc-filter-control"><button type="button" class="dc-btn dc-load">${__("Scan")}</button></div>
+					<div class="dc-fg dc-fg-period dc-period-field">
+						<div class="dc-fg-label dc-period-label">${__("From Year")}</div>
+						<input type="number" class="form-control dc-from-year" min="1950" max="2099">
+					</div>
+					<div class="dc-fg dc-fg-period dc-period-field">
+						<div class="dc-fg-label dc-period-label">${__("From Month")}</div>
+						<select class="form-control dc-from-month"></select>
+					</div>
+					<div class="dc-fg dc-fg-period dc-period-field">
+						<div class="dc-fg-label dc-period-label">${__("To Year")}</div>
+						<input type="number" class="form-control dc-to-year" min="1950" max="2099">
+					</div>
+					<div class="dc-fg dc-fg-period dc-period-field">
+						<div class="dc-fg-label dc-period-label">${__("To Month")}</div>
+						<select class="form-control dc-to-month"></select>
+					</div>
+					<div class="dc-fg dc-fg-action">
+						<div class="dc-fg-label">&nbsp;</div>
+						<button type="button" class="dc-btn dc-load">${__("Scan")}</button>
+					</div>
 				</div>
 			</div>
 			<div class="dc-emp-card"></div>
@@ -317,7 +338,7 @@ function init_data_cleansing($main) {
 		$main.find(".dc-mode-btn").removeClass("active");
 		$main.find(`.dc-mode-btn[data-mode="${state.scan_mode}"]`).addClass("active");
 		const period = state.scan_mode === "period";
-		$main.find(".dc-period-field, .dc-period-label").toggleClass("dc-period-disabled", !period);
+		$main.find(".dc-period-field").toggleClass("dc-period-disabled", !period);
 	}
 
 	$main.find(".dc-mode-btn").on("click", function () {

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
@@ -1,0 +1,17 @@
+frappe.pages["data-cleansing"].on_page_load = function (wrapper) {
+	frappe.ui.make_app_page({
+		parent: wrapper,
+		title: __("Data Cleansing"),
+		single_column: true,
+	});
+};
+
+frappe.pages["data-cleansing"].on_page_show = function (wrapper) {
+	const $main = $(wrapper).find(".layout-main-section");
+	$main.html(`
+		<div class="text-muted" style="padding: 1.5rem;">
+			<p>${__("Employee attendance & salary audit / cleanse.")}</p>
+			<p>${__("Implementation in progress — see specs/007-data-cleansing.md.")}</p>
+		</div>
+	`);
+};

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
@@ -8,6 +8,8 @@ frappe.pages["data-cleansing"].on_page_load = function (wrapper) {
 };
 
 frappe.pages["data-cleansing"].on_page_show = function (wrapper) {
+	// Keep standard Desk chrome (workspace sidebar) — do not go full-bleed
+	$("body").removeClass("full-width");
 	inject_dc_styles();
 	const $main = $(wrapper).find(".layout-main-section");
 	$main.html(dc_shell_html());
@@ -15,29 +17,36 @@ frappe.pages["data-cleansing"].on_page_show = function (wrapper) {
 };
 
 function inject_dc_styles() {
-	if (document.getElementById("dc-styles-v2")) return;
+	$("#dc-styles, #dc-styles-v2, #dc-styles-v3").remove();
 	const s = document.createElement("style");
-	s.id = "dc-styles-v2";
+	s.id = "dc-styles-v3";
 	s.innerHTML = `
-		.dc-root { padding: 12px 20px 48px; max-width: 1120px; margin: 0 auto; color: var(--text-color); }
+		.dc-root { padding: 8px 0 40px; color: var(--text-color); }
 		.dc-filter-card, .dc-emp-card, .dc-results-card {
 			background: var(--card-bg, var(--fg-color));
 			border: 1px solid var(--border-color);
-			border-radius: 10px;
-			box-shadow: 0 1px 2px rgba(0,0,0,.04);
-			margin-bottom: 14px;
+			border-radius: 8px;
+			margin-bottom: 12px;
 		}
 		.dc-filter-card { padding: 14px 16px; }
 		.dc-filter-row { display: flex; flex-wrap: wrap; gap: 12px 14px; align-items: flex-end; }
-		.dc-field { display: flex; flex-direction: column; gap: 5px; min-width: 120px; }
-		.dc-field-employee { min-width: 280px; flex: 1; }
+		.dc-field { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+		.dc-field-employee { width: 260px; flex: 0 0 260px; }
+		.dc-field-action { flex: 0 0 auto; }
 		.dc-field label {
 			font-size: 11px; font-weight: 700; color: var(--text-muted);
-			text-transform: uppercase; letter-spacing: .04em; margin: 0;
+			text-transform: uppercase; letter-spacing: .04em; margin: 0; line-height: 1.2;
+			min-height: 14px;
 		}
-		.dc-field .frappe-control { margin-bottom: 0 !important; }
+		.dc-field .frappe-control,
+		.dc-field .form-group { margin-bottom: 0 !important; }
+		.dc-field-employee .control-input-wrapper,
+		.dc-field-employee .awesomplete,
+		.dc-field-employee .awesomplete > input { width: 100% !important; }
+		.dc-field-employee input.input-with-feedback,
 		.dc-field .form-control, .dc-field select, .dc-field input[type=number] {
-			height: 32px; font-size: 13px; border-radius: 6px;
+			height: 32px !important; min-height: 32px !important;
+			font-size: 13px; border-radius: 6px; margin: 0;
 		}
 		.dc-mode-toggle {
 			display: inline-flex; border: 1px solid var(--border-color); border-radius: 6px;
@@ -45,17 +54,19 @@ function inject_dc_styles() {
 		}
 		.dc-mode-toggle button {
 			border: none; background: transparent; padding: 0 12px; font-size: 12px; font-weight: 600;
-			cursor: pointer; color: var(--text-muted); height: 100%;
+			cursor: pointer; color: var(--text-muted); height: 100%; white-space: nowrap;
 		}
 		.dc-mode-toggle button.active {
 			background: var(--fg-color); color: var(--text-color);
 			box-shadow: inset 0 0 0 1px var(--border-color);
 		}
 		.dc-period-fields { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
+		.dc-period-fields .dc-field { width: 110px; }
 		.dc-period-fields.dc-disabled { opacity: .4; pointer-events: none; }
 		.dc-btn {
-			height: 32px; padding: 0 16px; border: none; border-radius: 6px;
+			height: 32px; padding: 0 18px; border: none; border-radius: 6px;
 			background: var(--primary); color: #fff; font-size: 13px; font-weight: 600; cursor: pointer;
+			white-space: nowrap;
 		}
 		.dc-btn:hover { filter: brightness(.96); }
 		.dc-btn-ghost {
@@ -67,6 +78,14 @@ function inject_dc_styles() {
 			height: 28px; padding: 0 12px; border: none; border-radius: 6px;
 			background: var(--red-500, #e03131); color: #fff; font-size: 12px; font-weight: 600; cursor: pointer;
 		}
+		.dc-flag-filter {
+			display: inline-flex; border: 1px solid var(--border-color); border-radius: 6px; overflow: hidden; height: 28px;
+		}
+		.dc-flag-filter button {
+			border: none; background: transparent; padding: 0 11px; font-size: 12px; font-weight: 600;
+			color: var(--text-muted); cursor: pointer; height: 100%;
+		}
+		.dc-flag-filter button.active { background: var(--subtle-fg, #f1f3f5); color: var(--text-color); }
 
 		.dc-emp-card { display: none; padding: 16px 18px; }
 		.dc-emp-card.visible { display: block; }
@@ -94,15 +113,14 @@ function inject_dc_styles() {
 		.dc-pill.ok { background: #d3f9d8; color: #2b8a3e; }
 
 		.dc-results-header {
-			display: flex; align-items: center; justify-content: space-between; gap: 12px;
+			display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;
 			padding: 12px 16px; border-bottom: 1px solid var(--border-color);
 		}
 		.dc-results-title { font-size: 13px; font-weight: 700; }
 		.dc-results-sub { font-size: 12px; color: var(--text-muted); font-weight: 500; }
-		.dc-table-wrap { overflow: auto; max-height: min(62vh, 640px); }
+		.dc-table-wrap { overflow: visible; max-height: none; }
 		.dc-table { width: 100%; border-collapse: collapse; font-size: 13px; }
 		.dc-table thead th {
-			position: sticky; top: 0; z-index: 1;
 			padding: 9px 14px; text-align: left; font-size: 11px; font-weight: 700;
 			color: var(--text-muted); text-transform: uppercase; letter-spacing: .03em;
 			background: var(--subtle-fg, #f8f9fa); border-bottom: 1px solid var(--border-color);
@@ -121,9 +139,7 @@ function inject_dc_styles() {
 		}
 		.dc-flag.warn { background: #fff3bf; color: #5c4800; }
 		.dc-flag.bad { background: #ffe3e3; color: #c92a2a; }
-		.dc-empty {
-			padding: 40px 20px; text-align: center; color: var(--text-muted); font-size: 13px;
-		}
+		.dc-empty { padding: 40px 20px; text-align: center; color: var(--text-muted); font-size: 13px; }
 		.dc-empty-title { font-weight: 600; color: var(--text-color); margin-bottom: 4px; }
 
 		.dc-dialog-body { padding: 4px 2px 8px; }
@@ -154,6 +170,7 @@ function inject_dc_styles() {
 		.dc-hint { font-size: 12px; color: var(--text-muted); }
 		@media (max-width: 720px) {
 			.dc-dialog-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+			.dc-field-employee { width: 100%; flex: 1 1 100%; }
 		}
 	`;
 	document.head.appendChild(s);
@@ -181,7 +198,10 @@ function dc_shell_html() {
 						<div class="dc-field"><label>${__("To Year")}</label><input type="number" class="form-control dc-to-year" min="1950" max="2099"></div>
 						<div class="dc-field"><label>${__("To Month")}</label><select class="form-control dc-to-month"></select></div>
 					</div>
-					<button type="button" class="dc-btn dc-load">${__("Scan")}</button>
+					<div class="dc-field dc-field-action">
+						<label>&nbsp;</label>
+						<button type="button" class="dc-btn dc-load">${__("Scan")}</button>
+					</div>
 				</div>
 			</div>
 			<div class="dc-emp-card"></div>
@@ -190,6 +210,11 @@ function dc_shell_html() {
 					<div>
 						<div class="dc-results-title">${__("Months with data")}</div>
 						<div class="dc-results-sub dc-results-hint">${__("Select an employee and scan to begin")}</div>
+					</div>
+					<div class="dc-flag-filter" title="${__("Filter months by flags")}">
+						<button type="button" class="dc-flag-btn active" data-filter="all">${__("All")}</button>
+						<button type="button" class="dc-flag-btn" data-filter="flagged">${__("Flagged")}</button>
+						<button type="button" class="dc-flag-btn" data-filter="unflagged">${__("Unflagged")}</button>
 					</div>
 				</div>
 				<div class="dc-matrix"><div class="dc-empty">${__("No scan yet.")}</div></div>
@@ -251,6 +276,7 @@ function init_data_cleansing($main) {
 		detail: null,
 		can_mutate: false,
 		scan_mode: "all",
+		flag_filter: "all",
 		dialog: null,
 	};
 
@@ -265,6 +291,13 @@ function init_data_cleansing($main) {
 		sync_mode_ui();
 	});
 	sync_mode_ui();
+
+	$main.find(".dc-flag-btn").on("click", function () {
+		state.flag_filter = $(this).data("filter");
+		$main.find(".dc-flag-btn").removeClass("active");
+		$(this).addClass("active");
+		render_matrix($main, state);
+	});
 
 	$main.find(".dc-load").on("click", () => load_matrix($main, state));
 }
@@ -336,20 +369,44 @@ function flag_class(flag) {
 	return "bad";
 }
 
+function filtered_rows(state) {
+	const rows = (state.matrix && state.matrix.months) || [];
+	const f = state.flag_filter || "all";
+	if (f === "flagged") return rows.filter((r) => (r.flags || []).length > 0);
+	if (f === "unflagged") return rows.filter((r) => !(r.flags || []).length);
+	return rows;
+}
+
 function render_matrix($main, state) {
 	const m = state.matrix || {};
-	const rows = m.months || [];
+	const all_rows = m.months || [];
+	const rows = filtered_rows(state);
 	const mode_label = m.scan_mode === "all" ? __("Whole data search") : __("Period scan");
+	const filter_label = {
+		all: __("All"),
+		flagged: __("Flagged"),
+		unflagged: __("Unflagged"),
+	}[state.flag_filter || "all"];
 
 	$main.find(".dc-results-hint").text(
-		__("{0} · {1} month(s)", [mode_label, rows.length])
+		__("{0} · showing {1} of {2} · {3}", [mode_label, rows.length, all_rows.length, filter_label])
 	);
 
-	if (!rows.length) {
+	if (!all_rows.length) {
 		$main.find(".dc-matrix").html(`
 			<div class="dc-empty">
 				<div class="dc-empty-title">${__("No attendance or salary slips found")}</div>
 				<div>${__("Try Whole data search, or widen the period.")}</div>
+			</div>
+		`);
+		return;
+	}
+
+	if (!rows.length) {
+		$main.find(".dc-matrix").html(`
+			<div class="dc-empty">
+				<div class="dc-empty-title">${__("No months match this filter")}</div>
+				<div>${__("Switch to All or another flag filter.")}</div>
 			</div>
 		`);
 		return;

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
@@ -31,9 +31,9 @@ function dc_set_breadcrumbs() {
 }
 
 function inject_dc_styles() {
-	$("#dc-styles, #dc-styles-v2, #dc-styles-v3, #dc-styles-v4, #dc-styles-v5, #dc-styles-v6, #dc-styles-v7").remove();
+	$("#dc-styles, #dc-styles-v2, #dc-styles-v3, #dc-styles-v4, #dc-styles-v5, #dc-styles-v6, #dc-styles-v7, #dc-styles-v8").remove();
 	const s = document.createElement("style");
-	s.id = "dc-styles-v7";
+	s.id = "dc-styles-v8";
 	s.innerHTML = `
 		.dc-root { padding: 8px 0 40px; color: var(--text-color); max-width: 100%; overflow-x: hidden; }
 		.dc-filter-card, .dc-emp-card, .dc-results-card {
@@ -160,19 +160,11 @@ function inject_dc_styles() {
 		}
 		.dc-results-title { font-size: 13px; font-weight: 700; }
 		.dc-results-sub { font-size: 12px; color: var(--text-muted); font-weight: 500; }
-		.dc-table-wrap {
-			overflow-x: auto;
-			overflow-y: visible;
-			max-height: none;
-			-webkit-overflow-scrolling: touch;
-			width: 100%;
-		}
+		.dc-table-wrap { overflow: visible; width: 100%; }
 		.dc-table {
 			width: 100%;
-			min-width: 760px;
 			border-collapse: collapse;
 			font-size: 13px;
-			table-layout: auto;
 		}
 		.dc-table thead th {
 			padding: 9px 12px; text-align: left; font-size: 11px; font-weight: 700;
@@ -183,35 +175,52 @@ function inject_dc_styles() {
 		.dc-table tbody td {
 			padding: 11px 12px; border-bottom: 1px solid var(--border-color);
 			vertical-align: middle;
-			white-space: nowrap;
 		}
 		.dc-table .dc-slip-cell {
-			max-width: 160px;
+			max-width: 180px;
 			overflow: hidden;
 			text-overflow: ellipsis;
+			white-space: nowrap;
 		}
-		.dc-table .dc-flags-cell {
-			white-space: normal;
-			min-width: 120px;
-		}
-		.dc-table .dc-actions-cell {
-			position: sticky;
-			right: 0;
-			background: var(--card-bg, var(--fg-color));
-			box-shadow: -6px 0 8px -6px rgba(0,0,0,.12);
-		}
-		.dc-table thead th.dc-actions-cell {
-			background: var(--subtle-fg, #f8f9fa);
-		}
-		.dc-table tbody tr:hover td.dc-actions-cell {
-			background: var(--highlight-color, rgba(0,0,0,.02));
-		}
-		.dc-table tbody tr.dc-has-flags td.dc-actions-cell {
-			background: #fffceb;
-		}
+		.dc-table .dc-flags-cell { white-space: normal; }
 		.dc-table tbody tr:last-child td { border-bottom: none; }
 		.dc-table tbody tr:hover td { background: var(--highlight-color, rgba(0,0,0,.02)); }
 		.dc-table tbody tr.dc-has-flags td { background: rgba(255, 224, 102, .08); }
+
+		.dc-month-cards { display: none; padding: 10px 12px 12px; }
+		.dc-month-card {
+			border: 1px solid var(--border-color);
+			border-radius: 8px;
+			padding: 12px;
+			margin-bottom: 10px;
+			background: var(--card-bg, var(--fg-color));
+		}
+		.dc-month-card:last-child { margin-bottom: 0; }
+		.dc-month-card.dc-has-flags { background: rgba(255, 224, 102, .08); border-color: #ffe066; }
+		.dc-month-card-top {
+			display: flex; align-items: flex-start; justify-content: space-between; gap: 10px;
+			margin-bottom: 10px;
+		}
+		.dc-month-card-title { font-size: 14px; font-weight: 700; margin: 0; }
+		.dc-month-card-grid {
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			gap: 8px 12px;
+			font-size: 12px;
+		}
+		.dc-month-card-grid .k { color: var(--text-muted); font-weight: 600; text-transform: uppercase; font-size: 10px; letter-spacing: .03em; }
+		.dc-month-card-grid .v { font-weight: 600; margin-top: 2px; word-break: break-word; }
+		.dc-month-card-flags { margin-top: 10px; }
+		.dc-month-card-actions { margin-top: 12px; }
+
+		@media (max-width: 900px) {
+			.dc-table-wrap { display: none; }
+			.dc-month-cards { display: block; }
+		}
+		@media (min-width: 901px) {
+			.dc-table-wrap { display: block; }
+			.dc-month-cards { display: none; }
+		}
 		.dc-flag {
 			display: inline-block; margin: 1px 4px 1px 0; padding: 2px 8px; border-radius: 10px;
 			font-size: 11px; font-weight: 600; background: var(--subtle-fg); color: var(--text-color);
@@ -514,8 +523,10 @@ function render_matrix($main, state) {
 		<th>${__("Slip")}</th>
 		<th>${__("Status")}</th>
 		<th>${__("Flags")}</th>
-		<th class="dc-actions-cell" style="width:88px"></th>
+		<th style="width:88px"></th>
 	</tr></thead><tbody>`;
+
+	let cards = `<div class="dc-month-cards">`;
 
 	rows.forEach((row) => {
 		const flags = (row.flags || []).map(
@@ -531,15 +542,31 @@ function render_matrix($main, state) {
 			<td class="dc-slip-cell" title="${slip}">${slip}</td>
 			<td>${frappe.utils.escape_html(row.slip_status)}</td>
 			<td class="dc-flags-cell">${flags || "—"}</td>
-			<td class="dc-actions-cell"><button type="button" class="dc-btn-ghost dc-view">${__("View")}</button></td>
+			<td><button type="button" class="dc-btn-ghost dc-view">${__("View")}</button></td>
 		</tr>`;
+
+		cards += `<div class="dc-month-card ${has_flags ? "dc-has-flags" : ""}" data-year="${row.year}" data-month="${row.month}">
+			<div class="dc-month-card-top">
+				<div class="dc-month-card-title">${frappe.utils.escape_html(row.month_label)}</div>
+				<button type="button" class="dc-btn-ghost dc-view">${__("View")}</button>
+			</div>
+			<div class="dc-month-card-grid">
+				<div><div class="k">${__("Att days")}</div><div class="v">${row.attendance_days}</div></div>
+				<div><div class="k">${__("Expected")}</div><div class="v">${row.expected_days}</div></div>
+				<div><div class="k">${__("Coverage")}</div><div class="v">${frappe.utils.escape_html(row.coverage)}</div></div>
+				<div><div class="k">${__("Status")}</div><div class="v">${frappe.utils.escape_html(row.slip_status)}</div></div>
+				<div style="grid-column:1 / -1"><div class="k">${__("Slip")}</div><div class="v">${slip}</div></div>
+			</div>
+			${flags ? `<div class="dc-month-card-flags">${flags}</div>` : ""}
+		</div>`;
 	});
 	html += "</tbody></table></div>";
-	$main.find(".dc-matrix").html(html);
+	cards += "</div>";
+	$main.find(".dc-matrix").html(html + cards);
 
 	$main.find(".dc-matrix .dc-view").on("click", function () {
-		const $tr = $(this).closest("tr");
-		open_month_dialog($main, state, cint($tr.data("year")), cint($tr.data("month")));
+		const $row = $(this).closest("[data-year]");
+		open_month_dialog($main, state, cint($row.data("year")), cint($row.data("month")));
 	});
 }
 

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
@@ -31,18 +31,30 @@ function dc_set_breadcrumbs() {
 }
 
 function inject_dc_styles() {
-	$("#dc-styles, #dc-styles-v2, #dc-styles-v3, #dc-styles-v4, #dc-styles-v5, #dc-styles-v6, #dc-styles-v7, #dc-styles-v8").remove();
+	$("#dc-styles, #dc-styles-v2, #dc-styles-v3, #dc-styles-v4, #dc-styles-v5, #dc-styles-v6, #dc-styles-v7, #dc-styles-v8, #dc-styles-v9").remove();
 	const s = document.createElement("style");
-	s.id = "dc-styles-v8";
+	s.id = "dc-styles-v9";
 	s.innerHTML = `
-		.dc-root { padding: 8px 0 40px; color: var(--text-color); max-width: 100%; overflow-x: hidden; }
-		.dc-filter-card, .dc-emp-card, .dc-results-card {
+		.dc-root { padding: 8px 0 40px; color: var(--text-color); max-width: 100%; }
+		.dc-filter-card {
+			background: var(--card-bg, var(--fg-color));
+			border: 1px solid var(--border-color);
+			border-radius: 8px;
+			margin-bottom: 12px;
+			max-width: 100%;
+			overflow: visible;
+			position: relative;
+			z-index: 20;
+		}
+		.dc-emp-card, .dc-results-card {
 			background: var(--card-bg, var(--fg-color));
 			border: 1px solid var(--border-color);
 			border-radius: 8px;
 			margin-bottom: 12px;
 			max-width: 100%;
 			overflow: hidden;
+			position: relative;
+			z-index: 1;
 		}
 		.dc-filter-card { padding: 14px 16px; }
 		.dc-filter-row {
@@ -76,6 +88,12 @@ function inject_dc_styles() {
 		.dc-employee-wrap .control-input-wrapper,
 		.dc-employee-wrap .awesomplete,
 		.dc-employee-wrap .awesomplete > input { width: 100% !important; }
+		.dc-employee-wrap .awesomplete { position: relative; z-index: 30; }
+		.dc-employee-wrap .awesomplete > ul {
+			z-index: 40 !important;
+			max-height: 240px;
+			overflow-y: auto;
+		}
 		.dc-employee-wrap input.input-with-feedback,
 		.dc-fg .form-control,
 		.dc-fg select,

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
@@ -53,6 +53,16 @@ function inject_dc_styles() {
 		.dc-att-row { display: flex; align-items: center; gap: 10px; padding: 6px 10px; border-bottom: 1px solid var(--border-color); font-size: 13px; }
 		.dc-att-row:last-child { border-bottom: none; }
 		.dc-slip-row { display: flex; align-items: center; gap: 10px; padding: 8px 0; border-bottom: 1px solid var(--border-color); font-size: 13px; }
+		.dc-mode-toggle {
+			display: inline-flex; border: 1px solid var(--border-color); border-radius: var(--border-radius);
+			overflow: hidden; height: 30px; align-self: flex-end;
+		}
+		.dc-mode-toggle button {
+			border: none; background: transparent; padding: 0 12px; font-size: 12px; font-weight: 600;
+			cursor: pointer; color: var(--text-muted); height: 100%;
+		}
+		.dc-mode-toggle button.active { background: var(--primary); color: #fff; }
+		.dc-period-fields.dc-disabled { opacity: 0.45; pointer-events: none; }
 	`;
 	document.head.appendChild(s);
 }
@@ -62,10 +72,16 @@ function dc_shell_html() {
 		<div class="dc-root">
 			<div class="dc-filter-bar">
 				<div class="dc-field" style="min-width:260px"><label>${__("Employee")}</label><div class="dc-employee"></div></div>
-				<div class="dc-field"><label>${__("From Year")}</label><input type="number" class="form-control dc-from-year" min="1950" max="2099"></div>
-				<div class="dc-field"><label>${__("From Month")}</label><select class="form-control dc-from-month"></select></div>
-				<div class="dc-field"><label>${__("To Year")}</label><input type="number" class="form-control dc-to-year" min="1950" max="2099"></div>
-				<div class="dc-field"><label>${__("To Month")}</label><select class="form-control dc-to-month"></select></div>
+				<div class="dc-mode-toggle" title="${__("Period scan uses From–To. Whole data search lists every month with attendance or slips.")}">
+					<button type="button" class="dc-mode-btn" data-mode="period">${__("Period scan")}</button>
+					<button type="button" class="dc-mode-btn active" data-mode="all">${__("Whole data search")}</button>
+				</div>
+				<div class="dc-period-fields dc-disabled" style="display:flex;gap:12px;flex-wrap:wrap;align-items:flex-end;">
+					<div class="dc-field"><label>${__("From Year")}</label><input type="number" class="form-control dc-from-year" min="1950" max="2099"></div>
+					<div class="dc-field"><label>${__("From Month")}</label><select class="form-control dc-from-month"></select></div>
+					<div class="dc-field"><label>${__("To Year")}</label><input type="number" class="form-control dc-to-year" min="1950" max="2099"></div>
+					<div class="dc-field"><label>${__("To Month")}</label><select class="form-control dc-to-month"></select></div>
+				</div>
 				<button class="dc-btn dc-load">${__("Load")}</button>
 			</div>
 			<div class="dc-meta"></div>
@@ -114,7 +130,20 @@ function init_data_cleansing($main) {
 		matrix: null,
 		detail: null,
 		can_mutate: false,
+		scan_mode: "all",
 	};
+
+	function sync_mode_ui() {
+		$main.find(".dc-mode-btn").removeClass("active");
+		$main.find(`.dc-mode-btn[data-mode="${state.scan_mode}"]`).addClass("active");
+		$main.find(".dc-period-fields").toggleClass("dc-disabled", state.scan_mode !== "period");
+	}
+
+	$main.find(".dc-mode-btn").on("click", function () {
+		state.scan_mode = $(this).data("mode");
+		sync_mode_ui();
+	});
+	sync_mode_ui();
 
 	$main.find(".dc-load").on("click", () => load_matrix($main, state));
 }
@@ -127,11 +156,14 @@ function load_matrix($main, state, after) {
 	}
 	const args = {
 		employee,
-		from_year: cint($main.find(".dc-from-year").val()),
-		from_month: cint($main.find(".dc-from-month").val()),
-		to_year: cint($main.find(".dc-to-year").val()),
-		to_month: cint($main.find(".dc-to-month").val()),
+		scan_mode: state.scan_mode || "all",
 	};
+	if (args.scan_mode === "period") {
+		args.from_year = cint($main.find(".dc-from-year").val());
+		args.from_month = cint($main.find(".dc-from-month").val());
+		args.to_year = cint($main.find(".dc-to-year").val());
+		args.to_month = cint($main.find(".dc-to-month").val());
+	}
 
 	$main.find(".dc-matrix").html(`<div class="dc-empty">${__("Loading…")}</div>`);
 	if (!after) $main.find(".dc-detail-wrap").empty();
@@ -160,10 +192,16 @@ function render_matrix($main, state) {
 		m.left_date ? `${__("Left")} ${frappe.datetime.str_to_user(m.left_date)}` : null,
 	].filter(Boolean).join(" · ");
 
+	const mode_label = m.scan_mode === "all"
+		? __("Whole data search")
+		: __("Period scan");
+
 	$main.find(".dc-meta").html(
 		`<strong>${frappe.utils.escape_html(m.employee_name || m.employee)}</strong>`
 		+ ` · ${frappe.utils.escape_html(m.company || "")}`
 		+ (tenure ? ` · ${tenure}` : "")
+		+ ` · ${mode_label}`
+		+ ` · ${(m.months || []).length} ${__("month(s) with data")}`
 		+ (state.can_mutate ? "" : ` · <span class="text-muted">${__("View only")}</span>`)
 	);
 

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
@@ -31,16 +31,18 @@ function dc_set_breadcrumbs() {
 }
 
 function inject_dc_styles() {
-	$("#dc-styles, #dc-styles-v2, #dc-styles-v3, #dc-styles-v4, #dc-styles-v5, #dc-styles-v6").remove();
+	$("#dc-styles, #dc-styles-v2, #dc-styles-v3, #dc-styles-v4, #dc-styles-v5, #dc-styles-v6, #dc-styles-v7").remove();
 	const s = document.createElement("style");
-	s.id = "dc-styles-v6";
+	s.id = "dc-styles-v7";
 	s.innerHTML = `
-		.dc-root { padding: 8px 0 40px; color: var(--text-color); }
+		.dc-root { padding: 8px 0 40px; color: var(--text-color); max-width: 100%; overflow-x: hidden; }
 		.dc-filter-card, .dc-emp-card, .dc-results-card {
 			background: var(--card-bg, var(--fg-color));
 			border: 1px solid var(--border-color);
 			border-radius: 8px;
 			margin-bottom: 12px;
+			max-width: 100%;
+			overflow: hidden;
 		}
 		.dc-filter-card { padding: 14px 16px; }
 		.dc-filter-row {
@@ -158,17 +160,54 @@ function inject_dc_styles() {
 		}
 		.dc-results-title { font-size: 13px; font-weight: 700; }
 		.dc-results-sub { font-size: 12px; color: var(--text-muted); font-weight: 500; }
-		.dc-table-wrap { overflow: visible; max-height: none; }
-		.dc-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+		.dc-table-wrap {
+			overflow-x: auto;
+			overflow-y: visible;
+			max-height: none;
+			-webkit-overflow-scrolling: touch;
+			width: 100%;
+		}
+		.dc-table {
+			width: 100%;
+			min-width: 760px;
+			border-collapse: collapse;
+			font-size: 13px;
+			table-layout: auto;
+		}
 		.dc-table thead th {
-			padding: 9px 14px; text-align: left; font-size: 11px; font-weight: 700;
+			padding: 9px 12px; text-align: left; font-size: 11px; font-weight: 700;
 			color: var(--text-muted); text-transform: uppercase; letter-spacing: .03em;
 			background: var(--subtle-fg, #f8f9fa); border-bottom: 1px solid var(--border-color);
 			white-space: nowrap;
 		}
 		.dc-table tbody td {
-			padding: 11px 14px; border-bottom: 1px solid var(--border-color);
+			padding: 11px 12px; border-bottom: 1px solid var(--border-color);
 			vertical-align: middle;
+			white-space: nowrap;
+		}
+		.dc-table .dc-slip-cell {
+			max-width: 160px;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+		.dc-table .dc-flags-cell {
+			white-space: normal;
+			min-width: 120px;
+		}
+		.dc-table .dc-actions-cell {
+			position: sticky;
+			right: 0;
+			background: var(--card-bg, var(--fg-color));
+			box-shadow: -6px 0 8px -6px rgba(0,0,0,.12);
+		}
+		.dc-table thead th.dc-actions-cell {
+			background: var(--subtle-fg, #f8f9fa);
+		}
+		.dc-table tbody tr:hover td.dc-actions-cell {
+			background: var(--highlight-color, rgba(0,0,0,.02));
+		}
+		.dc-table tbody tr.dc-has-flags td.dc-actions-cell {
+			background: #fffceb;
 		}
 		.dc-table tbody tr:last-child td { border-bottom: none; }
 		.dc-table tbody tr:hover td { background: var(--highlight-color, rgba(0,0,0,.02)); }
@@ -475,7 +514,7 @@ function render_matrix($main, state) {
 		<th>${__("Slip")}</th>
 		<th>${__("Status")}</th>
 		<th>${__("Flags")}</th>
-		<th style="width:88px"></th>
+		<th class="dc-actions-cell" style="width:88px"></th>
 	</tr></thead><tbody>`;
 
 	rows.forEach((row) => {
@@ -483,15 +522,16 @@ function render_matrix($main, state) {
 			(f) => `<span class="dc-flag ${flag_class(f)}">${frappe.utils.escape_html(f)}</span>`
 		).join("");
 		const has_flags = (row.flags || []).length > 0;
+		const slip = frappe.utils.escape_html(row.slip_names || "—");
 		html += `<tr class="${has_flags ? "dc-has-flags" : ""}" data-year="${row.year}" data-month="${row.month}">
 			<td><strong>${frappe.utils.escape_html(row.month_label)}</strong></td>
 			<td>${row.attendance_days}</td>
 			<td>${row.expected_days}</td>
 			<td>${frappe.utils.escape_html(row.coverage)}</td>
-			<td>${frappe.utils.escape_html(row.slip_names)}</td>
+			<td class="dc-slip-cell" title="${slip}">${slip}</td>
 			<td>${frappe.utils.escape_html(row.slip_status)}</td>
-			<td>${flags || "—"}</td>
-			<td><button type="button" class="dc-btn-ghost dc-view">${__("View")}</button></td>
+			<td class="dc-flags-cell">${flags || "—"}</td>
+			<td class="dc-actions-cell"><button type="button" class="dc-btn-ghost dc-view">${__("View")}</button></td>
 		</tr>`;
 	});
 	html += "</tbody></table></div>";

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
@@ -15,54 +15,146 @@ frappe.pages["data-cleansing"].on_page_show = function (wrapper) {
 };
 
 function inject_dc_styles() {
-	if (document.getElementById("dc-styles")) return;
+	if (document.getElementById("dc-styles-v2")) return;
 	const s = document.createElement("style");
-	s.id = "dc-styles";
+	s.id = "dc-styles-v2";
 	s.innerHTML = `
-		.dc-root { padding: 0 20px 40px; font-family: var(--font-stack); color: var(--text-color); }
-		.dc-filter-bar { display: flex; align-items: flex-end; gap: 12px; flex-wrap: wrap; padding: 16px 0 12px; }
-		.dc-field { display: flex; flex-direction: column; gap: 4px; min-width: 140px; }
-		.dc-field label { font-size: 11px; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
+		.dc-root { padding: 12px 20px 48px; max-width: 1120px; margin: 0 auto; color: var(--text-color); }
+		.dc-filter-card, .dc-emp-card, .dc-results-card {
+			background: var(--card-bg, var(--fg-color));
+			border: 1px solid var(--border-color);
+			border-radius: 10px;
+			box-shadow: 0 1px 2px rgba(0,0,0,.04);
+			margin-bottom: 14px;
+		}
+		.dc-filter-card { padding: 14px 16px; }
+		.dc-filter-row { display: flex; flex-wrap: wrap; gap: 12px 14px; align-items: flex-end; }
+		.dc-field { display: flex; flex-direction: column; gap: 5px; min-width: 120px; }
+		.dc-field-employee { min-width: 280px; flex: 1; }
+		.dc-field label {
+			font-size: 11px; font-weight: 700; color: var(--text-muted);
+			text-transform: uppercase; letter-spacing: .04em; margin: 0;
+		}
 		.dc-field .frappe-control { margin-bottom: 0 !important; }
-		.dc-btn {
-			height: 30px; padding: 0 14px; background: var(--primary); color: #fff;
-			border: none; border-radius: var(--border-radius); font-size: 12px; font-weight: 600; cursor: pointer;
+		.dc-field .form-control, .dc-field select, .dc-field input[type=number] {
+			height: 32px; font-size: 13px; border-radius: 6px;
 		}
-		.dc-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-		.dc-btn-outline {
-			height: 28px; padding: 0 10px; background: transparent; color: var(--text-color);
-			border: 1px solid var(--border-color); border-radius: var(--border-radius); font-size: 12px; cursor: pointer;
-		}
-		.dc-btn-danger { background: var(--red-500, #e03131); color: #fff; border: none; }
-		.dc-meta { font-size: 13px; color: var(--text-muted); margin-bottom: 12px; }
-		.dc-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-		.dc-table th, .dc-table td { border-bottom: 1px solid var(--border-color); padding: 8px 10px; text-align: left; vertical-align: top; }
-		.dc-table th { font-size: 11px; text-transform: uppercase; color: var(--text-muted); font-weight: 600; }
-		.dc-table tr:hover td { background: var(--fg-hover, rgba(0,0,0,0.02)); }
-		.dc-flag {
-			display: inline-block; margin: 1px 4px 1px 0; padding: 1px 7px; border-radius: 10px;
-			font-size: 11px; background: var(--bg-light-gray, #f1f3f5); color: var(--text-color);
-		}
-		.dc-flag.warn { background: #fff3bf; color: #5c4800; }
-		.dc-flag.bad { background: #ffe3e3; color: #c92a2a; }
-		.dc-empty { padding: 24px 0; color: var(--text-muted); }
-		.dc-detail { margin-top: 20px; border: 1px solid var(--border-color); border-radius: 8px; padding: 14px 16px; }
-		.dc-detail h4 { margin: 0 0 10px; font-size: 14px; }
-		.dc-detail-actions { display: flex; gap: 8px; flex-wrap: wrap; margin: 10px 0 14px; }
-		.dc-att-list { max-height: 280px; overflow: auto; border: 1px solid var(--border-color); border-radius: 6px; }
-		.dc-att-row { display: flex; align-items: center; gap: 10px; padding: 6px 10px; border-bottom: 1px solid var(--border-color); font-size: 13px; }
-		.dc-att-row:last-child { border-bottom: none; }
-		.dc-slip-row { display: flex; align-items: center; gap: 10px; padding: 8px 0; border-bottom: 1px solid var(--border-color); font-size: 13px; }
 		.dc-mode-toggle {
-			display: inline-flex; border: 1px solid var(--border-color); border-radius: var(--border-radius);
-			overflow: hidden; height: 30px; align-self: flex-end;
+			display: inline-flex; border: 1px solid var(--border-color); border-radius: 6px;
+			overflow: hidden; height: 32px; background: var(--control-bg, var(--bg-color));
 		}
 		.dc-mode-toggle button {
 			border: none; background: transparent; padding: 0 12px; font-size: 12px; font-weight: 600;
 			cursor: pointer; color: var(--text-muted); height: 100%;
 		}
-		.dc-mode-toggle button.active { background: var(--primary); color: #fff; }
-		.dc-period-fields.dc-disabled { opacity: 0.45; pointer-events: none; }
+		.dc-mode-toggle button.active {
+			background: var(--fg-color); color: var(--text-color);
+			box-shadow: inset 0 0 0 1px var(--border-color);
+		}
+		.dc-period-fields { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
+		.dc-period-fields.dc-disabled { opacity: .4; pointer-events: none; }
+		.dc-btn {
+			height: 32px; padding: 0 16px; border: none; border-radius: 6px;
+			background: var(--primary); color: #fff; font-size: 13px; font-weight: 600; cursor: pointer;
+		}
+		.dc-btn:hover { filter: brightness(.96); }
+		.dc-btn-ghost {
+			height: 28px; padding: 0 10px; border: 1px solid var(--border-color); border-radius: 6px;
+			background: transparent; color: var(--text-color); font-size: 12px; font-weight: 600; cursor: pointer;
+		}
+		.dc-btn-ghost:hover { background: var(--subtle-fg, rgba(0,0,0,.03)); }
+		.dc-btn-danger {
+			height: 28px; padding: 0 12px; border: none; border-radius: 6px;
+			background: var(--red-500, #e03131); color: #fff; font-size: 12px; font-weight: 600; cursor: pointer;
+		}
+
+		.dc-emp-card { display: none; padding: 16px 18px; }
+		.dc-emp-card.visible { display: block; }
+		.dc-emp-top { display: flex; gap: 14px; align-items: center; }
+		.dc-avatar {
+			width: 44px; height: 44px; border-radius: 50%; flex-shrink: 0;
+			display: flex; align-items: center; justify-content: center;
+			font-size: 14px; font-weight: 700; color: #fff; background: var(--text-muted);
+		}
+		.dc-emp-name { font-size: 16px; font-weight: 700; line-height: 1.25; margin: 0 0 2px; }
+		.dc-emp-id { font-size: 12px; color: var(--text-muted); }
+		.dc-emp-meta {
+			display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+			gap: 10px 16px; margin-top: 14px; padding-top: 14px;
+			border-top: 1px solid var(--border-color);
+		}
+		.dc-emp-meta-item .k { font-size: 11px; color: var(--text-muted); font-weight: 600; text-transform: uppercase; letter-spacing: .03em; }
+		.dc-emp-meta-item .v { font-size: 13px; font-weight: 600; margin-top: 2px; }
+		.dc-pill {
+			display: inline-flex; align-items: center; height: 22px; padding: 0 8px;
+			border-radius: 11px; font-size: 11px; font-weight: 600;
+			background: var(--subtle-fg, #f1f3f5); color: var(--text-muted);
+		}
+		.dc-pill.warn { background: #fff3bf; color: #5c4800; }
+		.dc-pill.ok { background: #d3f9d8; color: #2b8a3e; }
+
+		.dc-results-header {
+			display: flex; align-items: center; justify-content: space-between; gap: 12px;
+			padding: 12px 16px; border-bottom: 1px solid var(--border-color);
+		}
+		.dc-results-title { font-size: 13px; font-weight: 700; }
+		.dc-results-sub { font-size: 12px; color: var(--text-muted); font-weight: 500; }
+		.dc-table-wrap { overflow: auto; max-height: min(62vh, 640px); }
+		.dc-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+		.dc-table thead th {
+			position: sticky; top: 0; z-index: 1;
+			padding: 9px 14px; text-align: left; font-size: 11px; font-weight: 700;
+			color: var(--text-muted); text-transform: uppercase; letter-spacing: .03em;
+			background: var(--subtle-fg, #f8f9fa); border-bottom: 1px solid var(--border-color);
+			white-space: nowrap;
+		}
+		.dc-table tbody td {
+			padding: 11px 14px; border-bottom: 1px solid var(--border-color);
+			vertical-align: middle;
+		}
+		.dc-table tbody tr:last-child td { border-bottom: none; }
+		.dc-table tbody tr:hover td { background: var(--highlight-color, rgba(0,0,0,.02)); }
+		.dc-table tbody tr.dc-has-flags td { background: rgba(255, 224, 102, .08); }
+		.dc-flag {
+			display: inline-block; margin: 1px 4px 1px 0; padding: 2px 8px; border-radius: 10px;
+			font-size: 11px; font-weight: 600; background: var(--subtle-fg); color: var(--text-color);
+		}
+		.dc-flag.warn { background: #fff3bf; color: #5c4800; }
+		.dc-flag.bad { background: #ffe3e3; color: #c92a2a; }
+		.dc-empty {
+			padding: 40px 20px; text-align: center; color: var(--text-muted); font-size: 13px;
+		}
+		.dc-empty-title { font-weight: 600; color: var(--text-color); margin-bottom: 4px; }
+
+		.dc-dialog-body { padding: 4px 2px 8px; }
+		.dc-dialog-summary {
+			display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px;
+			margin-bottom: 14px;
+		}
+		.dc-dialog-stat {
+			border: 1px solid var(--border-color); border-radius: 8px; padding: 10px 12px;
+			background: var(--subtle-fg, #f8f9fa);
+		}
+		.dc-dialog-stat .k { font-size: 11px; color: var(--text-muted); font-weight: 600; text-transform: uppercase; }
+		.dc-dialog-stat .v { font-size: 14px; font-weight: 700; margin-top: 3px; }
+		.dc-section-label {
+			font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em;
+			color: var(--text-muted); margin: 14px 0 8px;
+		}
+		.dc-slip-row, .dc-att-row {
+			display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+			padding: 8px 0; border-bottom: 1px solid var(--border-color); font-size: 13px;
+		}
+		.dc-slip-row:last-child, .dc-att-row:last-child { border-bottom: none; }
+		.dc-att-list {
+			max-height: 280px; overflow: auto; border: 1px solid var(--border-color);
+			border-radius: 8px; padding: 4px 10px;
+		}
+		.dc-dialog-actions { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin: 4px 0 8px; }
+		.dc-hint { font-size: 12px; color: var(--text-muted); }
+		@media (max-width: 720px) {
+			.dc-dialog-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+		}
 	`;
 	document.head.appendChild(s);
 }
@@ -70,23 +162,38 @@ function inject_dc_styles() {
 function dc_shell_html() {
 	return `
 		<div class="dc-root">
-			<div class="dc-filter-bar">
-				<div class="dc-field" style="min-width:260px"><label>${__("Employee")}</label><div class="dc-employee"></div></div>
-				<div class="dc-mode-toggle" title="${__("Period scan uses From–To. Whole data search lists every month with attendance or slips.")}">
-					<button type="button" class="dc-mode-btn" data-mode="period">${__("Period scan")}</button>
-					<button type="button" class="dc-mode-btn active" data-mode="all">${__("Whole data search")}</button>
+			<div class="dc-filter-card">
+				<div class="dc-filter-row">
+					<div class="dc-field dc-field-employee">
+						<label>${__("Employee")}</label>
+						<div class="dc-employee"></div>
+					</div>
+					<div class="dc-field">
+						<label>${__("Scan mode")}</label>
+						<div class="dc-mode-toggle" title="${__("Period scan uses From–To. Whole data search lists every month with attendance or slips.")}">
+							<button type="button" class="dc-mode-btn" data-mode="period">${__("Period scan")}</button>
+							<button type="button" class="dc-mode-btn active" data-mode="all">${__("Whole data search")}</button>
+						</div>
+					</div>
+					<div class="dc-period-fields dc-disabled">
+						<div class="dc-field"><label>${__("From Year")}</label><input type="number" class="form-control dc-from-year" min="1950" max="2099"></div>
+						<div class="dc-field"><label>${__("From Month")}</label><select class="form-control dc-from-month"></select></div>
+						<div class="dc-field"><label>${__("To Year")}</label><input type="number" class="form-control dc-to-year" min="1950" max="2099"></div>
+						<div class="dc-field"><label>${__("To Month")}</label><select class="form-control dc-to-month"></select></div>
+					</div>
+					<button type="button" class="dc-btn dc-load">${__("Scan")}</button>
 				</div>
-				<div class="dc-period-fields dc-disabled" style="display:flex;gap:12px;flex-wrap:wrap;align-items:flex-end;">
-					<div class="dc-field"><label>${__("From Year")}</label><input type="number" class="form-control dc-from-year" min="1950" max="2099"></div>
-					<div class="dc-field"><label>${__("From Month")}</label><select class="form-control dc-from-month"></select></div>
-					<div class="dc-field"><label>${__("To Year")}</label><input type="number" class="form-control dc-to-year" min="1950" max="2099"></div>
-					<div class="dc-field"><label>${__("To Month")}</label><select class="form-control dc-to-month"></select></div>
-				</div>
-				<button class="dc-btn dc-load">${__("Load")}</button>
 			</div>
-			<div class="dc-meta"></div>
-			<div class="dc-matrix"></div>
-			<div class="dc-detail-wrap"></div>
+			<div class="dc-emp-card"></div>
+			<div class="dc-results-card">
+				<div class="dc-results-header">
+					<div>
+						<div class="dc-results-title">${__("Months with data")}</div>
+						<div class="dc-results-sub dc-results-hint">${__("Select an employee and scan to begin")}</div>
+					</div>
+				</div>
+				<div class="dc-matrix"><div class="dc-empty">${__("No scan yet.")}</div></div>
+			</div>
 		</div>
 	`;
 }
@@ -96,6 +203,13 @@ const DC_MONTHS = [
 	"July","August","September","October","November","December"
 ];
 
+function dc_initials(name) {
+	const parts = String(name || "").trim().split(/\s+/).filter(Boolean);
+	if (!parts.length) return "?";
+	if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+	return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
 function init_data_cleansing($main) {
 	const now = new Date();
 	const year = now.getFullYear();
@@ -104,8 +218,8 @@ function init_data_cleansing($main) {
 	const $fromMonth = $main.find(".dc-from-month");
 	const $toMonth = $main.find(".dc-to-month");
 	DC_MONTHS.forEach((label, i) => {
-		$fromMonth.append(`<option value="${i + 1}">${label}</option>`);
-		$toMonth.append(`<option value="${i + 1}">${label}</option>`);
+		$fromMonth.append(`<option value="${i + 1}">${__(label)}</option>`);
+		$toMonth.append(`<option value="${i + 1}">${__(label)}</option>`);
 	});
 	$main.find(".dc-from-year").val(year);
 	$main.find(".dc-to-year").val(year);
@@ -118,8 +232,14 @@ function init_data_cleansing($main) {
 			fieldtype: "Link",
 			options: "Company Link",
 			fieldname: "employee",
-			placeholder: __("Select Company Link"),
+			placeholder: __("Search employee / Company Link"),
 			only_select: 1,
+			change() {
+				const val = employee_control.get_value();
+				if (!val) {
+					$main.find(".dc-emp-card").removeClass("visible").empty();
+				}
+			},
 		},
 		render_input: true,
 	});
@@ -131,6 +251,7 @@ function init_data_cleansing($main) {
 		detail: null,
 		can_mutate: false,
 		scan_mode: "all",
+		dialog: null,
 	};
 
 	function sync_mode_ui() {
@@ -165,8 +286,8 @@ function load_matrix($main, state, after) {
 		args.to_month = cint($main.find(".dc-to-month").val());
 	}
 
-	$main.find(".dc-matrix").html(`<div class="dc-empty">${__("Loading…")}</div>`);
-	if (!after) $main.find(".dc-detail-wrap").empty();
+	$main.find(".dc-matrix").html(`<div class="dc-empty">${__("Scanning…")}</div>`);
+	$main.find(".dc-results-hint").text(__("Loading…"));
 
 	frappe.call({
 		method: "saral_hr.saral_hr.page.data_cleansing.data_cleansing.get_employee_month_matrix",
@@ -174,10 +295,40 @@ function load_matrix($main, state, after) {
 		callback(r) {
 			state.matrix = r.message || {};
 			state.can_mutate = !!state.matrix.can_mutate;
+			render_employee_card($main, state);
 			render_matrix($main, state);
 			if (typeof after === "function") after();
 		},
 	});
+}
+
+function render_employee_card($main, state) {
+	const m = state.matrix || {};
+	const name = m.employee_name || m.employee || "";
+	const mode_label = m.scan_mode === "all" ? __("Whole data search") : __("Period scan");
+	const months = (m.months || []).length;
+	const flagged = (m.months || []).filter((row) => (row.flags || []).length).length;
+
+	$main.find(".dc-emp-card").addClass("visible").html(`
+		<div class="dc-emp-top">
+			<div class="dc-avatar">${frappe.utils.escape_html(dc_initials(name))}</div>
+			<div style="flex:1;min-width:0">
+				<div class="dc-emp-name">${frappe.utils.escape_html(name)}</div>
+				<div class="dc-emp-id">${frappe.utils.escape_html(m.employee || "")}</div>
+			</div>
+			<span class="dc-pill ${state.can_mutate ? "ok" : "warn"}">
+				${state.can_mutate ? __("Can cleanse") : __("View only")}
+			</span>
+		</div>
+		<div class="dc-emp-meta">
+			<div class="dc-emp-meta-item"><div class="k">${__("Company")}</div><div class="v">${frappe.utils.escape_html(m.company || "—")}</div></div>
+			<div class="dc-emp-meta-item"><div class="k">${__("Joined")}</div><div class="v">${m.date_of_joining ? frappe.datetime.str_to_user(m.date_of_joining) : "—"}</div></div>
+			<div class="dc-emp-meta-item"><div class="k">${__("Left")}</div><div class="v">${m.left_date ? frappe.datetime.str_to_user(m.left_date) : __("Active")}</div></div>
+			<div class="dc-emp-meta-item"><div class="k">${__("Scan")}</div><div class="v">${frappe.utils.escape_html(mode_label)}</div></div>
+			<div class="dc-emp-meta-item"><div class="k">${__("Months found")}</div><div class="v">${months}</div></div>
+			<div class="dc-emp-meta-item"><div class="k">${__("Flagged")}</div><div class="v">${flagged}</div></div>
+		</div>
+	`);
 }
 
 function flag_class(flag) {
@@ -186,102 +337,135 @@ function flag_class(flag) {
 }
 
 function render_matrix($main, state) {
-	const m = state.matrix;
-	const tenure = [
-		m.date_of_joining ? `${__("Joined")} ${frappe.datetime.str_to_user(m.date_of_joining)}` : null,
-		m.left_date ? `${__("Left")} ${frappe.datetime.str_to_user(m.left_date)}` : null,
-	].filter(Boolean).join(" · ");
+	const m = state.matrix || {};
+	const rows = m.months || [];
+	const mode_label = m.scan_mode === "all" ? __("Whole data search") : __("Period scan");
 
-	const mode_label = m.scan_mode === "all"
-		? __("Whole data search")
-		: __("Period scan");
-
-	$main.find(".dc-meta").html(
-		`<strong>${frappe.utils.escape_html(m.employee_name || m.employee)}</strong>`
-		+ ` · ${frappe.utils.escape_html(m.company || "")}`
-		+ (tenure ? ` · ${tenure}` : "")
-		+ ` · ${mode_label}`
-		+ ` · ${(m.months || []).length} ${__("month(s) with data")}`
-		+ (state.can_mutate ? "" : ` · <span class="text-muted">${__("View only")}</span>`)
+	$main.find(".dc-results-hint").text(
+		__("{0} · {1} month(s)", [mode_label, rows.length])
 	);
 
-	const rows = m.months || [];
 	if (!rows.length) {
-		$main.find(".dc-matrix").html(`<div class="dc-empty">${__("No attendance or salary slips in this range.")}</div>`);
+		$main.find(".dc-matrix").html(`
+			<div class="dc-empty">
+				<div class="dc-empty-title">${__("No attendance or salary slips found")}</div>
+				<div>${__("Try Whole data search, or widen the period.")}</div>
+			</div>
+		`);
 		return;
 	}
 
-	let html = `<table class="dc-table"><thead><tr>
-		<th>${__("Month")}</th><th>${__("Att days")}</th><th>${__("Expected")}</th>
-		<th>${__("Coverage")}</th><th>${__("Slip")}</th><th>${__("Slip status")}</th>
-		<th>${__("Flags")}</th><th></th>
+	let html = `<div class="dc-table-wrap"><table class="dc-table"><thead><tr>
+		<th>${__("Month")}</th>
+		<th>${__("Att days")}</th>
+		<th>${__("Expected")}</th>
+		<th>${__("Coverage")}</th>
+		<th>${__("Slip")}</th>
+		<th>${__("Status")}</th>
+		<th>${__("Flags")}</th>
+		<th style="width:88px"></th>
 	</tr></thead><tbody>`;
 
 	rows.forEach((row) => {
 		const flags = (row.flags || []).map(
 			(f) => `<span class="dc-flag ${flag_class(f)}">${frappe.utils.escape_html(f)}</span>`
 		).join("");
-		html += `<tr data-year="${row.year}" data-month="${row.month}">
-			<td>${frappe.utils.escape_html(row.month_label)}</td>
+		const has_flags = (row.flags || []).length > 0;
+		html += `<tr class="${has_flags ? "dc-has-flags" : ""}" data-year="${row.year}" data-month="${row.month}">
+			<td><strong>${frappe.utils.escape_html(row.month_label)}</strong></td>
 			<td>${row.attendance_days}</td>
 			<td>${row.expected_days}</td>
 			<td>${frappe.utils.escape_html(row.coverage)}</td>
 			<td>${frappe.utils.escape_html(row.slip_names)}</td>
 			<td>${frappe.utils.escape_html(row.slip_status)}</td>
 			<td>${flags || "—"}</td>
-			<td><button class="dc-btn-outline dc-view">${__("View")}</button></td>
+			<td><button type="button" class="dc-btn-ghost dc-view">${__("View")}</button></td>
 		</tr>`;
 	});
-	html += "</tbody></table>";
+	html += "</tbody></table></div>";
 	$main.find(".dc-matrix").html(html);
 
 	$main.find(".dc-matrix .dc-view").on("click", function () {
 		const $tr = $(this).closest("tr");
-		load_detail($main, state, cint($tr.data("year")), cint($tr.data("month")));
+		open_month_dialog($main, state, cint($tr.data("year")), cint($tr.data("month")));
 	});
 }
 
-function load_detail($main, state, year, month) {
+function open_month_dialog($main, state, year, month) {
 	frappe.call({
 		method: "saral_hr.saral_hr.page.data_cleansing.data_cleansing.get_month_detail",
 		args: { employee: state.matrix.employee, year, month },
+		freeze: true,
+		freeze_message: __("Loading month…"),
 		callback(r) {
 			state.detail = r.message;
-			render_detail($main, state);
+			show_month_dialog($main, state);
 		},
 	});
 }
 
-function render_detail($main, state) {
+function show_month_dialog($main, state) {
 	const d = state.detail;
 	if (!d) return;
 	const can = state.can_mutate;
 	const summary = d.summary || {};
-	const label = summary.month_label || `${d.month_start}`;
+	const label = summary.month_label || d.month_start;
+	const emp_name = state.matrix.employee_name || state.matrix.employee;
 
-	let actions = "";
+	if (state.dialog) {
+		state.dialog.hide();
+		state.dialog = null;
+	}
+
+	const dialog = new frappe.ui.Dialog({
+		title: __("{0} — {1}", [emp_name, label]),
+		size: "large",
+		fields: [{ fieldtype: "HTML", fieldname: "body" }],
+		primary_action_label: can ? __("Close") : __("Done"),
+		primary_action() {
+			dialog.hide();
+		},
+	});
+	state.dialog = dialog;
+
+	const $body = $(dialog.fields_dict.body.wrapper);
+	$body.html(build_dialog_body_html(d, can, label));
+	bind_dialog_actions($body, $main, state, dialog, d, label);
+	dialog.show();
+}
+
+function build_dialog_body_html(d, can, label) {
+	const summary = d.summary || {};
+	const flags = (summary.flags || []).map(
+		(f) => `<span class="dc-flag ${flag_class(f)}">${frappe.utils.escape_html(f)}</span>`
+	).join("") || "—";
+
+	let actions = `<div class="dc-dialog-actions">`;
 	if (can) {
 		if ((d.slips || []).length) {
-			actions += `<span class="text-muted" style="font-size:12px">${__("Delete attendance is blocked until all slips for this month are removed.")}</span>`;
+			actions += `<span class="dc-hint">${__("Remove all slips for this month before deleting attendance.")}</span>`;
 		} else if ((d.attendance || []).length) {
-			actions += `<button class="dc-btn dc-btn-danger dc-del-month">${__("Delete all attendance this month")}</button>`;
-			actions += `<button class="dc-btn-outline dc-del-selected">${__("Delete selected days")}</button>`;
+			actions += `<button type="button" class="dc-btn-danger dc-del-month">${__("Delete all attendance")}</button>`;
+			actions += `<button type="button" class="dc-btn-ghost dc-del-selected">${__("Delete selected days")}</button>`;
 		}
+	} else {
+		actions += `<span class="dc-hint">${__("View only — ask a Manager to cleanse.")}</span>`;
 	}
+	actions += `</div>`;
 
 	let slips_html = "";
 	(d.slips || []).forEach((s) => {
-		let btns = `<a href="/app/salary-slip/${encodeURIComponent(s.name)}" target="_blank">${frappe.utils.escape_html(s.name)}</a>`;
-		btns += ` · ${frappe.utils.escape_html(s.status)}`;
+		let row = `<a href="/app/salary-slip/${encodeURIComponent(s.name)}" target="_blank">${frappe.utils.escape_html(s.name)}</a>`;
+		row += ` <span class="dc-pill">${frappe.utils.escape_html(s.status)}</span>`;
 		if (can && s.docstatus === 1) {
-			btns += ` <button class="dc-btn-outline dc-cancel-slip" data-name="${frappe.utils.escape_html(s.name)}">${__("Cancel")}</button>`;
+			row += ` <button type="button" class="dc-btn-ghost dc-cancel-slip" data-name="${frappe.utils.escape_html(s.name)}">${__("Cancel")}</button>`;
 		}
 		if (can && s.docstatus !== 1) {
-			btns += ` <button class="dc-btn-outline dc-del-slip" data-name="${frappe.utils.escape_html(s.name)}">${__("Delete")}</button>`;
+			row += ` <button type="button" class="dc-btn-ghost dc-del-slip" data-name="${frappe.utils.escape_html(s.name)}">${__("Delete")}</button>`;
 		}
-		slips_html += `<div class="dc-slip-row">${btns}</div>`;
+		slips_html += `<div class="dc-slip-row">${row}</div>`;
 	});
-	if (!slips_html) slips_html = `<div class="text-muted">${__("No salary slips")}</div>`;
+	if (!slips_html) slips_html = `<div class="dc-hint">${__("No salary slips")}</div>`;
 
 	let att_html = "";
 	(d.attendance || []).forEach((a) => {
@@ -289,25 +473,34 @@ function render_detail($main, state) {
 			? `<input type="checkbox" class="dc-att-cb" value="${frappe.utils.escape_html(a.name)}">`
 			: "";
 		att_html += `<div class="dc-att-row">${cb}
-			<span style="width:110px">${frappe.datetime.str_to_user(a.attendance_date)}</span>
-			<span>${frappe.utils.escape_html(a.status)}</span>
+			<span style="width:110px;flex-shrink:0">${frappe.datetime.str_to_user(a.attendance_date)}</span>
+			<span style="min-width:100px">${frappe.utils.escape_html(a.status)}</span>
 			<a class="text-muted" href="/app/attendance/${encodeURIComponent(a.name)}" target="_blank">${frappe.utils.escape_html(a.name)}</a>
 		</div>`;
 	});
-	if (!att_html) att_html = `<div class="dc-empty">${__("No attendance rows")}</div>`;
+	if (!att_html) att_html = `<div class="dc-hint" style="padding:10px 0">${__("No attendance rows")}</div>`;
 
-	$main.find(".dc-detail-wrap").html(`
-		<div class="dc-detail">
-			<h4>${__("Detail")} — ${frappe.utils.escape_html(label)}</h4>
-			<div class="dc-detail-actions">${actions}</div>
-			<div style="margin-bottom:8px;font-weight:600">${__("Salary Slips")}</div>
+	return `
+		<div class="dc-dialog-body">
+			<div class="dc-dialog-summary">
+				<div class="dc-dialog-stat"><div class="k">${__("Attendance")}</div><div class="v">${summary.attendance_days || 0}</div></div>
+				<div class="dc-dialog-stat"><div class="k">${__("Expected")}</div><div class="v">${summary.expected_days || 0}</div></div>
+				<div class="dc-dialog-stat"><div class="k">${__("Coverage")}</div><div class="v">${frappe.utils.escape_html(summary.coverage || "—")}</div></div>
+				<div class="dc-dialog-stat"><div class="k">${__("Flags")}</div><div class="v" style="font-weight:500">${flags}</div></div>
+			</div>
+			${actions}
+			<div class="dc-section-label">${__("Salary Slips")}</div>
 			${slips_html}
-			<div style="margin:14px 0 8px;font-weight:600">${__("Attendance")} (${(d.attendance || []).length})</div>
+			<div class="dc-section-label">${__("Attendance")} (${(d.attendance || []).length})</div>
 			<div class="dc-att-list">${att_html}</div>
 		</div>
-	`);
+	`;
+}
 
-	$main.find(".dc-cancel-slip").on("click", function () {
+function bind_dialog_actions($body, $main, state, dialog, d, label) {
+	const summary = d.summary || {};
+
+	$body.find(".dc-cancel-slip").on("click", function () {
 		const name = $(this).data("name");
 		frappe.confirm(__("Cancel salary slip {0}?", [name]), () => {
 			frappe.call({
@@ -315,13 +508,13 @@ function render_detail($main, state) {
 				args: { name },
 				callback() {
 					frappe.show_alert({ message: __("Cancelled"), indicator: "green" });
-					reload_after_mutate($main, state, summary.year, summary.month);
+					reload_after_mutate($main, state, dialog, summary.year, summary.month);
 				},
 			});
 		});
 	});
 
-	$main.find(".dc-del-slip").on("click", function () {
+	$body.find(".dc-del-slip").on("click", function () {
 		const name = $(this).data("name");
 		frappe.confirm(__("Delete salary slip {0}? This cannot be undone.", [name]), () => {
 			frappe.call({
@@ -329,38 +522,35 @@ function render_detail($main, state) {
 				args: { name },
 				callback() {
 					frappe.show_alert({ message: __("Deleted"), indicator: "green" });
-					reload_after_mutate($main, state, summary.year, summary.month);
+					reload_after_mutate($main, state, dialog, summary.year, summary.month);
 				},
 			});
 		});
 	});
 
-	$main.find(".dc-del-month").on("click", () => {
+	$body.find(".dc-del-month").on("click", () => {
 		const n = (d.attendance || []).length;
-		frappe.confirm(
-			__("Delete {0} attendance row(s) for {1}?", [n, label]),
-			() => {
-				frappe.call({
-					method: "saral_hr.saral_hr.page.data_cleansing.data_cleansing.delete_attendance",
-					args: {
-						employee: state.matrix.employee,
-						year: summary.year,
-						month: summary.month,
-					},
-					callback(r) {
-						frappe.show_alert({
-							message: __("Deleted {0} attendance row(s)", [r.message.count]),
-							indicator: "green",
-						});
-						reload_after_mutate($main, state, summary.year, summary.month);
-					},
-				});
-			}
-		);
+		frappe.confirm(__("Delete {0} attendance row(s) for {1}?", [n, label]), () => {
+			frappe.call({
+				method: "saral_hr.saral_hr.page.data_cleansing.data_cleansing.delete_attendance",
+				args: {
+					employee: state.matrix.employee,
+					year: summary.year,
+					month: summary.month,
+				},
+				callback(r) {
+					frappe.show_alert({
+						message: __("Deleted {0} attendance row(s)", [r.message.count]),
+						indicator: "green",
+					});
+					reload_after_mutate($main, state, dialog, summary.year, summary.month);
+				},
+			});
+		});
 	});
 
-	$main.find(".dc-del-selected").on("click", () => {
-		const names = $main.find(".dc-att-cb:checked").map(function () { return this.value; }).get();
+	$body.find(".dc-del-selected").on("click", () => {
+		const names = $body.find(".dc-att-cb:checked").map(function () { return this.value; }).get();
 		if (!names.length) {
 			frappe.msgprint(__("Select at least one day"));
 			return;
@@ -374,15 +564,31 @@ function render_detail($main, state) {
 						message: __("Deleted {0} attendance row(s)", [r.message.count]),
 						indicator: "green",
 					});
-					reload_after_mutate($main, state, summary.year, summary.month);
+					reload_after_mutate($main, state, dialog, summary.year, summary.month);
 				},
 			});
 		});
 	});
 }
 
-function reload_after_mutate($main, state, year, month) {
+function reload_after_mutate($main, state, dialog, year, month) {
 	load_matrix($main, state, () => {
-		if (year && month) load_detail($main, state, year, month);
+		if (!(year && month)) {
+			if (dialog) dialog.hide();
+			return;
+		}
+		frappe.call({
+			method: "saral_hr.saral_hr.page.data_cleansing.data_cleansing.get_month_detail",
+			args: { employee: state.matrix.employee, year, month },
+			callback(r) {
+				state.detail = r.message;
+				if (!state.detail || (!(state.detail.attendance || []).length && !(state.detail.slips || []).length)) {
+					if (dialog) dialog.hide();
+					frappe.show_alert({ message: __("Month cleared"), indicator: "blue" });
+					return;
+				}
+				show_month_dialog($main, state);
+			},
+		});
 	});
 }

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.js
@@ -10,16 +10,30 @@ frappe.pages["data-cleansing"].on_page_load = function (wrapper) {
 frappe.pages["data-cleansing"].on_page_show = function (wrapper) {
 	// Keep standard Desk chrome (workspace sidebar) — do not go full-bleed
 	$("body").removeClass("full-width");
+	dc_set_breadcrumbs();
+	if (wrapper._dc_page) {
+		wrapper._dc_page.set_title(__("Data Cleansing"));
+	}
 	inject_dc_styles();
 	const $main = $(wrapper).find(".layout-main-section");
 	$main.html(dc_shell_html());
 	init_data_cleansing($main, wrapper._dc_page);
 };
 
+function dc_set_breadcrumbs() {
+	const $nb = $("#navbar-breadcrumbs");
+	if (!$nb.length) return;
+	$nb.empty().append(
+		`<li><a href="/app/saral-hr">${__("Saral HR")}</a></li>`,
+		`<li><a href="/app/data-cleansing">${__("Data Cleansing")}</a></li>`
+	);
+	document.title = __("Data Cleansing");
+}
+
 function inject_dc_styles() {
-	$("#dc-styles, #dc-styles-v2, #dc-styles-v3").remove();
+	$("#dc-styles, #dc-styles-v2, #dc-styles-v3, #dc-styles-v4, #dc-styles-v5").remove();
 	const s = document.createElement("style");
-	s.id = "dc-styles-v3";
+	s.id = "dc-styles-v5";
 	s.innerHTML = `
 		.dc-root { padding: 8px 0 40px; color: var(--text-color); }
 		.dc-filter-card, .dc-emp-card, .dc-results-card {
@@ -29,24 +43,42 @@ function inject_dc_styles() {
 			margin-bottom: 12px;
 		}
 		.dc-filter-card { padding: 14px 16px; }
-		.dc-filter-row { display: flex; flex-wrap: wrap; gap: 12px 14px; align-items: flex-end; }
-		.dc-field { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
-		.dc-field-employee { width: 260px; flex: 0 0 260px; }
-		.dc-field-action { flex: 0 0 auto; }
-		.dc-field label {
+		.dc-filter-grid {
+			display: grid;
+			grid-template-columns: minmax(220px, 1.1fr) max-content repeat(4, 108px) auto;
+			column-gap: 12px;
+			row-gap: 6px;
+			align-items: center;
+		}
+		.dc-filter-grid > .dc-filter-label {
+			grid-row: 1;
 			font-size: 11px; font-weight: 700; color: var(--text-muted);
 			text-transform: uppercase; letter-spacing: .04em; margin: 0; line-height: 1.2;
-			min-height: 14px;
 		}
-		.dc-field .frappe-control,
-		.dc-field .form-group { margin-bottom: 0 !important; }
-		.dc-field-employee .control-input-wrapper,
-		.dc-field-employee .awesomplete,
-		.dc-field-employee .awesomplete > input { width: 100% !important; }
-		.dc-field-employee input.input-with-feedback,
-		.dc-field .form-control, .dc-field select, .dc-field input[type=number] {
+		.dc-filter-grid > .dc-filter-control { grid-row: 2; min-width: 0; }
+		.dc-employee-wrap .frappe-control,
+		.dc-employee-wrap .form-group { margin-bottom: 0 !important; }
+		.dc-employee-wrap .control-label,
+		.dc-employee-wrap .help-box,
+		.dc-employee-wrap .clearfix { display: none !important; height: 0 !important; margin: 0 !important; padding: 0 !important; }
+		.dc-employee-wrap .control-input-wrapper,
+		.dc-employee-wrap .awesomplete,
+		.dc-employee-wrap .awesomplete > input { width: 100% !important; }
+		.dc-employee-wrap input.input-with-feedback,
+		.dc-filter-grid .form-control,
+		.dc-filter-grid select,
+		.dc-filter-grid input[type=number] {
 			height: 32px !important; min-height: 32px !important;
-			font-size: 13px; border-radius: 6px; margin: 0;
+			font-size: 13px; border-radius: 6px; margin: 0; width: 100%;
+		}
+		.dc-period-fields.dc-disabled,
+		.dc-period-disabled { opacity: .4; pointer-events: none; }
+		@media (max-width: 1100px) {
+			.dc-filter-grid {
+				grid-template-columns: repeat(2, minmax(160px, 1fr));
+			}
+			.dc-filter-grid > .dc-filter-label,
+			.dc-filter-grid > .dc-filter-control { grid-row: auto; }
 		}
 		.dc-mode-toggle {
 			display: inline-flex; border: 1px solid var(--border-color); border-radius: 6px;
@@ -60,8 +92,6 @@ function inject_dc_styles() {
 			background: var(--fg-color); color: var(--text-color);
 			box-shadow: inset 0 0 0 1px var(--border-color);
 		}
-		.dc-period-fields { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
-		.dc-period-fields .dc-field { width: 110px; }
 		.dc-period-fields.dc-disabled { opacity: .4; pointer-events: none; }
 		.dc-btn {
 			height: 32px; padding: 0 18px; border: none; border-radius: 6px;
@@ -180,28 +210,27 @@ function dc_shell_html() {
 	return `
 		<div class="dc-root">
 			<div class="dc-filter-card">
-				<div class="dc-filter-row">
-					<div class="dc-field dc-field-employee">
-						<label>${__("Employee")}</label>
-						<div class="dc-employee"></div>
-					</div>
-					<div class="dc-field">
-						<label>${__("Scan mode")}</label>
+				<div class="dc-filter-grid">
+					<div class="dc-filter-label">${__("Employee")}</div>
+					<div class="dc-filter-label">${__("Scan mode")}</div>
+					<div class="dc-filter-label dc-period-label">${__("From Year")}</div>
+					<div class="dc-filter-label dc-period-label">${__("From Month")}</div>
+					<div class="dc-filter-label dc-period-label">${__("To Year")}</div>
+					<div class="dc-filter-label dc-period-label">${__("To Month")}</div>
+					<div class="dc-filter-label">&nbsp;</div>
+
+					<div class="dc-filter-control dc-employee-wrap"><div class="dc-employee"></div></div>
+					<div class="dc-filter-control">
 						<div class="dc-mode-toggle" title="${__("Period scan uses From–To. Whole data search lists every month with attendance or slips.")}">
 							<button type="button" class="dc-mode-btn" data-mode="period">${__("Period scan")}</button>
 							<button type="button" class="dc-mode-btn active" data-mode="all">${__("Whole data search")}</button>
 						</div>
 					</div>
-					<div class="dc-period-fields dc-disabled">
-						<div class="dc-field"><label>${__("From Year")}</label><input type="number" class="form-control dc-from-year" min="1950" max="2099"></div>
-						<div class="dc-field"><label>${__("From Month")}</label><select class="form-control dc-from-month"></select></div>
-						<div class="dc-field"><label>${__("To Year")}</label><input type="number" class="form-control dc-to-year" min="1950" max="2099"></div>
-						<div class="dc-field"><label>${__("To Month")}</label><select class="form-control dc-to-month"></select></div>
-					</div>
-					<div class="dc-field dc-field-action">
-						<label>&nbsp;</label>
-						<button type="button" class="dc-btn dc-load">${__("Scan")}</button>
-					</div>
+					<div class="dc-filter-control dc-period-field"><input type="number" class="form-control dc-from-year" min="1950" max="2099"></div>
+					<div class="dc-filter-control dc-period-field"><select class="form-control dc-from-month"></select></div>
+					<div class="dc-filter-control dc-period-field"><input type="number" class="form-control dc-to-year" min="1950" max="2099"></div>
+					<div class="dc-filter-control dc-period-field"><select class="form-control dc-to-month"></select></div>
+					<div class="dc-filter-control"><button type="button" class="dc-btn dc-load">${__("Scan")}</button></div>
 				</div>
 			</div>
 			<div class="dc-emp-card"></div>
@@ -257,8 +286,10 @@ function init_data_cleansing($main) {
 			fieldtype: "Link",
 			options: "Company Link",
 			fieldname: "employee",
+			label: __("Employee"),
 			placeholder: __("Search employee / Company Link"),
 			only_select: 1,
+			hidden: 0,
 			change() {
 				const val = employee_control.get_value();
 				if (!val) {
@@ -269,6 +300,8 @@ function init_data_cleansing($main) {
 		render_input: true,
 	});
 	employee_control.refresh();
+	// Link control ships its own label — hide it so our grid labels stay aligned
+	$main.find(".dc-employee .control-label, .dc-employee .help-box").hide();
 
 	const state = {
 		employee_control,
@@ -283,7 +316,8 @@ function init_data_cleansing($main) {
 	function sync_mode_ui() {
 		$main.find(".dc-mode-btn").removeClass("active");
 		$main.find(`.dc-mode-btn[data-mode="${state.scan_mode}"]`).addClass("active");
-		$main.find(".dc-period-fields").toggleClass("dc-disabled", state.scan_mode !== "period");
+		const period = state.scan_mode === "period";
+		$main.find(".dc-period-field, .dc-period-label").toggleClass("dc-period-disabled", !period);
 	}
 
 	$main.find(".dc-mode-btn").on("click", function () {

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.json
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.json
@@ -1,0 +1,26 @@
+{
+ "creation": "2026-08-08 00:00:00.000000",
+ "doctype": "Page",
+ "idx": 0,
+ "modified": "2026-08-08 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Saral Hr",
+ "name": "data-cleansing",
+ "owner": "Administrator",
+ "page_name": "data-cleansing",
+ "roles": [
+  {
+   "role": "Saral HR Manager"
+  },
+  {
+   "role": "Saral HR User"
+  },
+  {
+   "role": "System Manager"
+  }
+ ],
+ "script": null,
+ "standard": "Yes",
+ "style": null,
+ "title": "Data Cleansing"
+}

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.py
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.py
@@ -1,4 +1,411 @@
 # Copyright (c) 2026, sj and contributors
 # For license information, please see license.txt
 
-# APIs for Data Cleansing page — see specs/007-data-cleansing.md
+"""Data Cleansing page APIs — see specs/007-data-cleansing.md"""
+
+from __future__ import annotations
+
+import calendar
+import json
+from datetime import date
+
+import frappe
+from frappe import _
+from frappe.utils import get_first_day, get_last_day, getdate
+
+MONTH_NAMES = [
+	"January",
+	"February",
+	"March",
+	"April",
+	"May",
+	"June",
+	"July",
+	"August",
+	"September",
+	"October",
+	"November",
+	"December",
+]
+
+DOCSTATUS_LABEL = {0: "Draft", 1: "Submitted", 2: "Cancelled"}
+
+MUTATE_ROLES = {"Administrator", "System Manager", "Saral HR Manager"}
+VIEW_ROLES = MUTATE_ROLES | {"Saral HR User"}
+
+
+def _user_roles():
+	return set(frappe.get_roles(frappe.session.user))
+
+
+def _assert_can_view():
+	if frappe.session.user == "Administrator":
+		return
+	if not (_user_roles() & VIEW_ROLES):
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
+
+
+def _assert_can_mutate():
+	if frappe.session.user == "Administrator":
+		return
+	roles = _user_roles()
+	if "System Manager" in roles or "Saral HR Manager" in roles:
+		return
+	frappe.throw(_("Only Saral HR Manager or Administrator can cleanse data"), frappe.PermissionError)
+
+
+def _month_bounds(year: int, month: int):
+	start = date(int(year), int(month), 1)
+	end = date(int(year), int(month), calendar.monthrange(int(year), int(month))[1])
+	return start, end
+
+
+def _iter_months(from_year, from_month, to_year, to_month):
+	y, m = int(from_year), int(from_month)
+	ey, em = int(to_year), int(to_month)
+	if (y, m) > (ey, em):
+		frappe.throw(_("From month must be on or before To month"))
+	while (y, m) <= (ey, em):
+		yield y, m
+		if m == 12:
+			y, m = y + 1, 1
+		else:
+			m += 1
+
+
+def _tenure(employee: str):
+	row = frappe.db.get_value(
+		"Company Link",
+		employee,
+		["full_name", "company", "date_of_joining", "left_date"],
+		as_dict=True,
+	)
+	if not row:
+		frappe.throw(_("Employee {0} not found").format(employee))
+	return row
+
+
+def _expected_days(month_start: date, month_end: date, joining, left) -> int:
+	if not joining:
+		return 0
+	join = getdate(joining)
+	leave = getdate(left) if left else None
+	if join > month_end:
+		return 0
+	if leave and leave < month_start:
+		return 0
+	start = max(month_start, join)
+	end = min(month_end, leave) if leave else month_end
+	if start > end:
+		return 0
+	return (end - start).days + 1
+
+
+def _outside_tenure_dates(dates, joining, left) -> bool:
+	if not dates:
+		return False
+	join = getdate(joining) if joining else None
+	leave = getdate(left) if left else None
+	for d in dates:
+		gd = getdate(d)
+		if join and gd < join:
+			return True
+		if leave and gd > leave:
+			return True
+	return False
+
+
+def _write_log(*, employee, company, month_start, action, reference_names, counts, reason=None):
+	doc = frappe.get_doc(
+		{
+			"doctype": "Data Cleansing Log",
+			"employee": employee,
+			"company": company,
+			"month_start": month_start,
+			"action": action,
+			"reference_names": (
+				json.dumps(reference_names)
+				if isinstance(reference_names, (list, dict))
+				else (reference_names or "")
+			),
+			"counts": counts or 0,
+			"reason": reason or "",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _slips_for_month(employee: str, month_start: date, month_end: date):
+	return frappe.db.get_all(
+		"Salary Slip",
+		filters={
+			"employee": employee,
+			"start_date": ["between", [str(month_start), str(month_end)]],
+		},
+		fields=["name", "docstatus", "start_date", "end_date", "net_salary"],
+		order_by="docstatus asc, name asc",
+	)
+
+
+def _attendance_for_month(employee: str, month_start: date, month_end: date):
+	return frappe.db.get_all(
+		"Attendance",
+		filters={
+			"employee": employee,
+			"attendance_date": ["between", [str(month_start), str(month_end)]],
+		},
+		fields=["name", "attendance_date", "status", "docstatus"],
+		order_by="attendance_date asc",
+	)
+
+
+def _build_month_row(employee: str, tenure, year: int, month: int):
+	month_start, month_end = _month_bounds(year, month)
+	attendance = _attendance_for_month(employee, month_start, month_end)
+	slips = _slips_for_month(employee, month_start, month_end)
+	if not attendance and not slips:
+		return None
+
+	att_days = len(attendance)
+	expected = _expected_days(month_start, month_end, tenure.date_of_joining, tenure.left_date)
+	att_dates = [a.attendance_date for a in attendance]
+	slip_dates = [s.start_date for s in slips]
+
+	if expected == 0:
+		coverage = "Outside tenure"
+	elif att_days == 0:
+		coverage = "None"
+	elif att_days >= expected:
+		coverage = "Full"
+	else:
+		coverage = "Partial"
+
+	flags = []
+	if att_days and not slips:
+		flags.append("Attendance only")
+	if slips and att_days == 0:
+		flags.append("Slip only")
+	if _outside_tenure_dates(att_dates + slip_dates, tenure.date_of_joining, tenure.left_date):
+		flags.append("Outside tenure")
+	if expected > 0 and 0 < att_days < expected:
+		flags.append("Partial coverage")
+	if any(s.docstatus == 0 for s in slips):
+		flags.append("Draft slip")
+
+	statuses = sorted({DOCSTATUS_LABEL.get(s.docstatus, str(s.docstatus)) for s in slips})
+
+	return {
+		"year": year,
+		"month": month,
+		"month_label": f"{MONTH_NAMES[month - 1][:3]} {year}",
+		"month_start": str(month_start),
+		"month_end": str(month_end),
+		"attendance_days": att_days,
+		"expected_days": expected,
+		"coverage": coverage,
+		"slips": [
+			{
+				"name": s.name,
+				"docstatus": s.docstatus,
+				"status": DOCSTATUS_LABEL.get(s.docstatus, str(s.docstatus)),
+				"start_date": str(s.start_date) if s.start_date else None,
+				"net_salary": s.net_salary,
+			}
+			for s in slips
+		],
+		"slip_names": ", ".join(s.name for s in slips) if slips else "—",
+		"slip_status": ", ".join(statuses) if statuses else "—",
+		"flags": flags,
+		"can_delete_attendance": len(slips) == 0 and att_days > 0,
+	}
+
+
+@frappe.whitelist()
+def can_mutate():
+	_assert_can_view()
+	try:
+		_assert_can_mutate()
+		return True
+	except frappe.PermissionError:
+		return False
+
+
+@frappe.whitelist()
+def get_employee_month_matrix(employee, from_year, from_month, to_year, to_month):
+	"""Return month rows that have attendance and/or salary slips in range."""
+	_assert_can_view()
+	if not employee:
+		frappe.throw(_("Employee is required"))
+
+	tenure = _tenure(employee)
+	rows = []
+	for y, m in _iter_months(from_year, from_month, to_year, to_month):
+		row = _build_month_row(employee, tenure, y, m)
+		if row:
+			rows.append(row)
+
+	return {
+		"employee": employee,
+		"employee_name": tenure.full_name,
+		"company": tenure.company,
+		"date_of_joining": str(tenure.date_of_joining) if tenure.date_of_joining else None,
+		"left_date": str(tenure.left_date) if tenure.left_date else None,
+		"can_mutate": bool(
+			frappe.session.user == "Administrator"
+			or (_user_roles() & {"System Manager", "Saral HR Manager"})
+		),
+		"months": rows,
+	}
+
+
+@frappe.whitelist()
+def get_month_detail(employee, year, month):
+	_assert_can_view()
+	tenure = _tenure(employee)
+	month_start, month_end = _month_bounds(year, month)
+	attendance = _attendance_for_month(employee, month_start, month_end)
+	slips = _slips_for_month(employee, month_start, month_end)
+	row = _build_month_row(employee, tenure, int(year), int(month))
+
+	return {
+		"employee": employee,
+		"employee_name": tenure.full_name,
+		"company": tenure.company,
+		"month_start": str(month_start),
+		"month_end": str(month_end),
+		"summary": row,
+		"attendance": [
+			{
+				"name": a.name,
+				"attendance_date": str(a.attendance_date),
+				"status": a.status,
+			}
+			for a in attendance
+		],
+		"slips": [
+			{
+				"name": s.name,
+				"docstatus": s.docstatus,
+				"status": DOCSTATUS_LABEL.get(s.docstatus, str(s.docstatus)),
+				"start_date": str(s.start_date) if s.start_date else None,
+				"net_salary": s.net_salary,
+			}
+			for s in slips
+		],
+		"can_mutate": bool(
+			frappe.session.user == "Administrator"
+			or (_user_roles() & {"System Manager", "Saral HR Manager"})
+		),
+	}
+
+
+def _month_has_any_slip(employee: str, month_start: date, month_end: date) -> bool:
+	return bool(
+		frappe.db.exists(
+			"Salary Slip",
+			{
+				"employee": employee,
+				"start_date": ["between", [str(month_start), str(month_end)]],
+			},
+		)
+	)
+
+
+@frappe.whitelist()
+def delete_attendance(employee, names=None, year=None, month=None, reason=None):
+	"""Delete attendance by name list or whole month. Blocked if any slip exists."""
+	_assert_can_mutate()
+	if not employee:
+		frappe.throw(_("Employee is required"))
+
+	tenure = _tenure(employee)
+
+	if names:
+		if isinstance(names, str):
+			names = json.loads(names)
+		rows = frappe.db.get_all(
+			"Attendance",
+			filters={"name": ["in", names], "employee": employee},
+			fields=["name", "attendance_date"],
+		)
+		if not rows:
+			frappe.throw(_("No matching attendance found"))
+		# Use earliest date's month for slip check / log
+		dates = [getdate(r.attendance_date) for r in rows]
+		month_start = get_first_day(min(dates))
+		month_end = get_last_day(min(dates))
+	elif year and month:
+		month_start, month_end = _month_bounds(year, month)
+		rows = _attendance_for_month(employee, month_start, month_end)
+		if not rows:
+			frappe.throw(_("No attendance found for this month"))
+	else:
+		frappe.throw(_("Provide attendance names or year/month"))
+
+	if _month_has_any_slip(employee, month_start, month_end):
+		frappe.throw(
+			_(
+				"Cannot delete attendance while a Salary Slip exists for {0}. "
+				"Remove Draft, Submitted, and Cancelled slips for this month first."
+			).format(month_start.strftime("%b %Y"))
+		)
+
+	deleted = []
+	for r in rows:
+		frappe.delete_doc("Attendance", r.name, ignore_permissions=True, force=1)
+		deleted.append(r.name)
+
+	log_name = _write_log(
+		employee=employee,
+		company=tenure.company,
+		month_start=month_start,
+		action="delete_attendance",
+		reference_names=deleted,
+		counts=len(deleted),
+		reason=reason,
+	)
+	return {"deleted": deleted, "count": len(deleted), "log": log_name}
+
+
+@frappe.whitelist()
+def cancel_salary_slip(name, reason=None):
+	_assert_can_mutate()
+	doc = frappe.get_doc("Salary Slip", name)
+	if doc.docstatus != 1:
+		frappe.throw(_("Salary Slip {0} is not Submitted").format(name))
+	doc.cancel()
+	log_name = _write_log(
+		employee=doc.employee,
+		company=doc.company,
+		month_start=get_first_day(getdate(doc.start_date)),
+		action="cancel_salary_slip",
+		reference_names=[name],
+		counts=1,
+		reason=reason,
+	)
+	return {"name": name, "docstatus": 2, "log": log_name}
+
+
+@frappe.whitelist()
+def delete_salary_slip(name, reason=None):
+	_assert_can_mutate()
+	doc = frappe.get_doc("Salary Slip", name)
+	if doc.docstatus == 1:
+		frappe.throw(
+			_("Cancel Salary Slip {0} before deleting").format(name)
+		)
+	employee = doc.employee
+	company = doc.company
+	month_start = get_first_day(getdate(doc.start_date))
+	frappe.delete_doc("Salary Slip", name, ignore_permissions=True, force=1)
+	log_name = _write_log(
+		employee=employee,
+		company=company,
+		month_start=month_start,
+		action="delete_salary_slip",
+		reference_names=[name],
+		counts=1,
+		reason=reason,
+	)
+	return {"deleted": name, "log": log_name}

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.py
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.py
@@ -149,12 +149,15 @@ TENURE_FILLER_STATUSES = {"Absent"}
 
 
 def _should_flag_outside_tenure(attendance, slips, expected, joining, left) -> bool:
-	"""True for cleansing anomalies — not for intentional Absent fillers in a tenure month."""
+	"""True for cleansing anomalies — not for intentional Absent fillers or mid-month join slips.
+
+	Salary slips always use month ``start_date`` (1st). A slip in a month that overlaps
+	tenure is normal even when the 1st is before joining / after left_date.
+	"""
+	# Entire calendar month outside employment, yet data exists
 	if expected == 0 and (attendance or slips):
 		return True
-	for s in slips or []:
-		if _date_outside_tenure(s.start_date, joining, left):
-			return True
+	# Non-Absent attendance on dates outside joining–left (Present/leave after left, etc.)
 	for a in attendance or []:
 		if not _date_outside_tenure(a.attendance_date, joining, left):
 			continue

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.py
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.py
@@ -73,6 +73,36 @@ def _iter_months(from_year, from_month, to_year, to_month):
 			m += 1
 
 
+def _discover_months_with_data(employee: str):
+	"""All distinct (year, month) that have Attendance or Salary Slip for employee."""
+	months = set()
+	for row in frappe.db.sql(
+		"""
+		SELECT DISTINCT YEAR(attendance_date) AS y, MONTH(attendance_date) AS m
+		FROM `tabAttendance`
+		WHERE employee = %s AND attendance_date IS NOT NULL
+		""",
+		employee,
+		as_dict=True,
+	):
+		if row.y and row.m:
+			months.add((int(row.y), int(row.m)))
+
+	for row in frappe.db.sql(
+		"""
+		SELECT DISTINCT YEAR(start_date) AS y, MONTH(start_date) AS m
+		FROM `tabSalary Slip`
+		WHERE employee = %s AND start_date IS NOT NULL
+		""",
+		employee,
+		as_dict=True,
+	):
+		if row.y and row.m:
+			months.add((int(row.y), int(row.m)))
+
+	return sorted(months)
+
+
 def _tenure(employee: str):
 	row = frappe.db.get_value(
 		"Company Link",
@@ -232,18 +262,44 @@ def can_mutate():
 
 
 @frappe.whitelist()
-def get_employee_month_matrix(employee, from_year, from_month, to_year, to_month):
-	"""Return month rows that have attendance and/or salary slips in range."""
+def get_employee_month_matrix(
+	employee,
+	from_year=None,
+	from_month=None,
+	to_year=None,
+	to_month=None,
+	scan_mode="period",
+):
+	"""Return month rows that have attendance and/or salary slips.
+
+	scan_mode:
+	  - period: only months in [from, to]
+	  - all: every month that has any Attendance or Salary Slip (whole-data search)
+	"""
 	_assert_can_view()
 	if not employee:
 		frappe.throw(_("Employee is required"))
 
+	mode = (scan_mode or "period").strip().lower()
+	if mode not in ("period", "all"):
+		frappe.throw(_("Invalid scan mode"))
+
 	tenure = _tenure(employee)
 	rows = []
-	for y, m in _iter_months(from_year, from_month, to_year, to_month):
-		row = _build_month_row(employee, tenure, y, m)
-		if row:
-			rows.append(row)
+
+	if mode == "all":
+		month_keys = _discover_months_with_data(employee)
+		for y, m in month_keys:
+			row = _build_month_row(employee, tenure, y, m)
+			if row:
+				rows.append(row)
+	else:
+		if from_year is None or from_month is None or to_year is None or to_month is None:
+			frappe.throw(_("From and To month are required for Period scan"))
+		for y, m in _iter_months(from_year, from_month, to_year, to_month):
+			row = _build_month_row(employee, tenure, y, m)
+			if row:
+				rows.append(row)
 
 	return {
 		"employee": employee,
@@ -251,6 +307,7 @@ def get_employee_month_matrix(employee, from_year, from_month, to_year, to_month
 		"company": tenure.company,
 		"date_of_joining": str(tenure.date_of_joining) if tenure.date_of_joining else None,
 		"left_date": str(tenure.left_date) if tenure.left_date else None,
+		"scan_mode": mode,
 		"can_mutate": bool(
 			frappe.session.user == "Administrator"
 			or (_user_roles() & {"System Manager", "Saral HR Manager"})

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.py
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026, sj and contributors
+# For license information, please see license.txt
+
+# APIs for Data Cleansing page — see specs/007-data-cleansing.md

--- a/saral_hr/saral_hr/page/data_cleansing/data_cleansing.py
+++ b/saral_hr/saral_hr/page/data_cleansing/data_cleansing.py
@@ -131,17 +131,36 @@ def _expected_days(month_start: date, month_end: date, joining, left) -> int:
 	return (end - start).days + 1
 
 
-def _outside_tenure_dates(dates, joining, left) -> bool:
-	if not dates:
+def _date_outside_tenure(d, joining, left) -> bool:
+	if not d:
 		return False
+	gd = getdate(d)
 	join = getdate(joining) if joining else None
 	leave = getdate(left) if left else None
-	for d in dates:
-		gd = getdate(d)
-		if join and gd < join:
+	if join and gd < join:
+		return True
+	if leave and gd > leave:
+		return True
+	return False
+
+
+# Pre-join / post-left Absent rows are intentional (salary payment-days scaffolding).
+TENURE_FILLER_STATUSES = {"Absent"}
+
+
+def _should_flag_outside_tenure(attendance, slips, expected, joining, left) -> bool:
+	"""True for cleansing anomalies — not for intentional Absent fillers in a tenure month."""
+	if expected == 0 and (attendance or slips):
+		return True
+	for s in slips or []:
+		if _date_outside_tenure(s.start_date, joining, left):
 			return True
-		if leave and gd > leave:
-			return True
+	for a in attendance or []:
+		if not _date_outside_tenure(a.attendance_date, joining, left):
+			continue
+		if (a.status or "").strip() in TENURE_FILLER_STATUSES:
+			continue
+		return True
 	return False
 
 
@@ -199,8 +218,6 @@ def _build_month_row(employee: str, tenure, year: int, month: int):
 
 	att_days = len(attendance)
 	expected = _expected_days(month_start, month_end, tenure.date_of_joining, tenure.left_date)
-	att_dates = [a.attendance_date for a in attendance]
-	slip_dates = [s.start_date for s in slips]
 
 	if expected == 0:
 		coverage = "Outside tenure"
@@ -216,7 +233,9 @@ def _build_month_row(employee: str, tenure, year: int, month: int):
 		flags.append("Attendance only")
 	if slips and att_days == 0:
 		flags.append("Slip only")
-	if _outside_tenure_dates(att_dates + slip_dates, tenure.date_of_joining, tenure.left_date):
+	if _should_flag_outside_tenure(
+		attendance, slips, expected, tenure.date_of_joining, tenure.left_date
+	):
 		flags.append("Outside tenure")
 	if expected > 0 and 0 < att_days < expected:
 		flags.append("Partial coverage")

--- a/saral_hr/saral_hr/workspace/saral_hr/saral_hr.json
+++ b/saral_hr/saral_hr/workspace/saral_hr/saral_hr.json
@@ -1,7 +1,7 @@
 {
  "charts": [],
  "content": "[{\"id\":\"quLY2RmqsK\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Saral HR</span>\",\"col\":12}},{\"id\":\"vX7k3MjFpF\",\"type\":\"card\",\"data\":{\"card_name\":\"Companies Master Data\",\"col\":4}},{\"id\":\"UXBG6dAVhA\",\"type\":\"card\",\"data\":{\"card_name\":\"Employees Master Data\",\"col\":4}},{\"id\":\"ONXHZ1p8Tv\",\"type\":\"card\",\"data\":{\"card_name\":\"Biometric\",\"col\":4}},{\"id\":\"tcNJEXnjQA\",\"type\":\"card\",\"data\":{\"card_name\":\"Salaries Master Data\",\"col\":4}},{\"id\":\"s7XR35vZsk\",\"type\":\"card\",\"data\":{\"card_name\":\"Monthly Transactions\",\"col\":4}},{\"id\":\"cLCTEGWswg\",\"type\":\"card\",\"data\":{\"card_name\":\"Leaves Process\",\"col\":4}},{\"id\":\"uJkw6_L_mY\",\"type\":\"card\",\"data\":{\"card_name\":\"Calculator\",\"col\":4}},{\"id\":\"ad8Ylo2JQq\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Salary Insight\",\"col\":3}},{\"id\":\"0meWuWmuDh\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Bulk Mark Attendance\",\"col\":3}},{\"id\":\"5CJdLnloTi\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Payroll Report\",\"col\":3}},{\"id\":\"DzpOy7QolO\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Salary Statistics\",\"col\":3}},{\"id\":\"I8XwI9v3a9\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Attendance Dashboard\",\"col\":3}},{\"id\":\"h0lo5909XG\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"HR Workforce & Payroll Overview\",\"col\":3}},{\"id\":\"0nabSA8nAP\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Daily Wage Attendance\",\"col\":3}},{\"id\":\"9q7-_C9IIg\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Daily Wage Calculation Report\",\"col\":3}},{\"id\":\"3QdfqOdCKN\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Company Enrollment Summary\",\"col\":3}},{\"id\":\"c4ZuQ0jrGJ\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Employee Timeline Report\",\"col\":3}},{\"id\":\"dcCard00001\",\"type\":\"card\",\"data\":{\"card_name\":\"Data Auditing and Cleansing\",\"col\":4}},{\"id\":\"z438-OXDAN\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Loan</b></span>\",\"col\":12}},{\"id\":\"__uwwFAuhL\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Employee Loan Advance Ledger\",\"col\":3}},{\"id\":\"RZYfyfGT_p\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Loan Deduction For Month\",\"col\":3}},{\"id\":\"-4YhGslVjM\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Loan Register\",\"col\":3}},{\"id\":\"MEoIy75QHi\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Advance Register\",\"col\":3}}]",
- "creation": "2026-06-18 12:04:31.266832",
+ "creation": "2026-08-08 10:47:39.927377",
  "custom_blocks": [],
  "docstatus": 0,
  "doctype": "Workspace",
@@ -386,7 +386,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-08-08 10:40:00.000000",
+ "modified": "2026-08-08 11:53:32.630041",
  "modified_by": "Administrator",
  "module": "Saral Hr",
  "name": "Saral HR",
@@ -410,6 +410,7 @@
    "doc_view": "List",
    "label": "Company Enrollment Summary",
    "link_to": "Company Enrollment Summary",
+   "report_ref_doctype": "Salary Structure Assignment",
    "type": "Report"
   },
   {
@@ -417,6 +418,7 @@
    "doc_view": "List",
    "label": "Employee Timeline Report",
    "link_to": "Employee Timeline Report",
+   "report_ref_doctype": "Company Link",
    "type": "Report"
   },
   {
@@ -424,6 +426,7 @@
    "doc_view": "List",
    "label": "Loan Deduction For Month",
    "link_to": "Loan Deduction For Month",
+   "report_ref_doctype": "Employee Loan Advance",
    "type": "Report"
   },
   {
@@ -431,6 +434,7 @@
    "doc_view": "List",
    "label": "Employee Loan Advance Ledger",
    "link_to": "Employee Loan Advance Ledger",
+   "report_ref_doctype": "Employee Loan Advance",
    "type": "Report"
   },
   {
@@ -438,6 +442,7 @@
    "doc_view": "List",
    "label": "Loan Register",
    "link_to": "Loan Register",
+   "report_ref_doctype": "Employee Loan Advance",
    "type": "Report"
   },
   {
@@ -452,6 +457,7 @@
    "doc_view": "List",
    "label": "Advance Register",
    "link_to": "Advance Register",
+   "report_ref_doctype": "Employee Loan Advance",
    "type": "Report"
   },
   {

--- a/saral_hr/saral_hr/workspace/saral_hr/saral_hr.json
+++ b/saral_hr/saral_hr/workspace/saral_hr/saral_hr.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"id\":\"quLY2RmqsK\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Saral HR</span>\",\"col\":12}},{\"id\":\"vX7k3MjFpF\",\"type\":\"card\",\"data\":{\"card_name\":\"Companies Master Data\",\"col\":4}},{\"id\":\"UXBG6dAVhA\",\"type\":\"card\",\"data\":{\"card_name\":\"Employees Master Data\",\"col\":4}},{\"id\":\"ONXHZ1p8Tv\",\"type\":\"card\",\"data\":{\"card_name\":\"Biometric\",\"col\":4}},{\"id\":\"tcNJEXnjQA\",\"type\":\"card\",\"data\":{\"card_name\":\"Salaries Master Data\",\"col\":4}},{\"id\":\"s7XR35vZsk\",\"type\":\"card\",\"data\":{\"card_name\":\"Monthly Transactions\",\"col\":4}},{\"id\":\"cLCTEGWswg\",\"type\":\"card\",\"data\":{\"card_name\":\"Leaves Process\",\"col\":4}},{\"id\":\"uJkw6_L_mY\",\"type\":\"card\",\"data\":{\"card_name\":\"Calculator\",\"col\":4}},{\"id\":\"ad8Ylo2JQq\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Salary Insight\",\"col\":3}},{\"id\":\"0meWuWmuDh\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Bulk Mark Attendance\",\"col\":3}},{\"id\":\"5CJdLnloTi\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Payroll Report\",\"col\":3}},{\"id\":\"DzpOy7QolO\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Salary Statistics\",\"col\":3}},{\"id\":\"I8XwI9v3a9\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Attendance Dashboard\",\"col\":3}},{\"id\":\"h0lo5909XG\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"HR Workforce & Payroll Overview\",\"col\":3}},{\"id\":\"0nabSA8nAP\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Daily Wage Attendance\",\"col\":3}},{\"id\":\"9q7-_C9IIg\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Daily Wage Calculation Report\",\"col\":3}},{\"id\":\"3QdfqOdCKN\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Company Enrollment Summary\",\"col\":3}},{\"id\":\"c4ZuQ0jrGJ\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Employee Timeline Report\",\"col\":3}},{\"id\":\"z438-OXDAN\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Loan</b></span>\",\"col\":12}},{\"id\":\"__uwwFAuhL\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Employee Loan Advance Ledger\",\"col\":3}},{\"id\":\"RZYfyfGT_p\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Loan Deduction For Month\",\"col\":3}},{\"id\":\"-4YhGslVjM\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Loan Register\",\"col\":3}},{\"id\":\"MEoIy75QHi\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Advance Register\",\"col\":3}}]",
+ "content": "[{\"id\":\"quLY2RmqsK\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Saral HR</span>\",\"col\":12}},{\"id\":\"vX7k3MjFpF\",\"type\":\"card\",\"data\":{\"card_name\":\"Companies Master Data\",\"col\":4}},{\"id\":\"UXBG6dAVhA\",\"type\":\"card\",\"data\":{\"card_name\":\"Employees Master Data\",\"col\":4}},{\"id\":\"ONXHZ1p8Tv\",\"type\":\"card\",\"data\":{\"card_name\":\"Biometric\",\"col\":4}},{\"id\":\"tcNJEXnjQA\",\"type\":\"card\",\"data\":{\"card_name\":\"Salaries Master Data\",\"col\":4}},{\"id\":\"s7XR35vZsk\",\"type\":\"card\",\"data\":{\"card_name\":\"Monthly Transactions\",\"col\":4}},{\"id\":\"cLCTEGWswg\",\"type\":\"card\",\"data\":{\"card_name\":\"Leaves Process\",\"col\":4}},{\"id\":\"uJkw6_L_mY\",\"type\":\"card\",\"data\":{\"card_name\":\"Calculator\",\"col\":4}},{\"id\":\"ad8Ylo2JQq\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Salary Insight\",\"col\":3}},{\"id\":\"0meWuWmuDh\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Bulk Mark Attendance\",\"col\":3}},{\"id\":\"5CJdLnloTi\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Payroll Report\",\"col\":3}},{\"id\":\"DzpOy7QolO\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Salary Statistics\",\"col\":3}},{\"id\":\"I8XwI9v3a9\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"View Attendance Dashboard\",\"col\":3}},{\"id\":\"h0lo5909XG\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"HR Workforce & Payroll Overview\",\"col\":3}},{\"id\":\"0nabSA8nAP\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Daily Wage Attendance\",\"col\":3}},{\"id\":\"9q7-_C9IIg\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Daily Wage Calculation Report\",\"col\":3}},{\"id\":\"3QdfqOdCKN\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Company Enrollment Summary\",\"col\":3}},{\"id\":\"c4ZuQ0jrGJ\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Employee Timeline Report\",\"col\":3}},{\"id\":\"dcCard00001\",\"type\":\"card\",\"data\":{\"card_name\":\"Data Auditing and Cleansing\",\"col\":4}},{\"id\":\"z438-OXDAN\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Loan</b></span>\",\"col\":12}},{\"id\":\"__uwwFAuhL\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Employee Loan Advance Ledger\",\"col\":3}},{\"id\":\"RZYfyfGT_p\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Loan Deduction For Month\",\"col\":3}},{\"id\":\"-4YhGslVjM\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Loan Register\",\"col\":3}},{\"id\":\"MEoIy75QHi\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Advance Register\",\"col\":3}}]",
  "creation": "2026-06-18 12:04:31.266832",
  "custom_blocks": [],
  "docstatus": 0,
@@ -365,9 +365,28 @@
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Data Auditing and Cleansing",
+   "link_count": 1,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Data Cleansing",
+   "link_count": 0,
+   "link_to": "data-cleansing",
+   "link_type": "Page",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2026-06-18 15:50:17.150386",
+ "modified": "2026-08-08 10:40:00.000000",
  "modified_by": "Administrator",
  "module": "Saral Hr",
  "name": "Saral HR",

--- a/saral_hr/tests/test_data_cleansing.py
+++ b/saral_hr/tests/test_data_cleansing.py
@@ -269,6 +269,30 @@ class TestDataCleansing(FrappeTestCase):
 		result = dc.get_employee_month_matrix(cl, 2024, 6, 2024, 6)
 		self.assertIn("Outside tenure", result["months"][0]["flags"])
 
+	def test_mid_month_join_slip_not_flagged_outside_tenure(self):
+		"""Slip start_date is month 1st; joining mid-month must not raise Outside tenure."""
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-09-08")
+		_make_attendance(cl, company, "2024-09-01", status="Absent")
+		_make_attendance(cl, company, "2024-09-08", status="Present")
+		_stub_slip(cl, company, "2024-09-01", docstatus=1)
+
+		result = dc.get_employee_month_matrix(cl, 2024, 9, 2024, 9)
+		row = result["months"][0]
+		self.assertGreater(row["expected_days"], 0)
+		self.assertNotIn("Outside tenure", row["flags"])
+
+	def test_present_after_left_flagged_outside_tenure(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-01-01", left="2025-03-08")
+		_make_attendance(cl, company, "2025-03-08", status="Present")
+		_make_attendance(cl, company, "2025-03-11", status="Present")
+
+		result = dc.get_employee_month_matrix(cl, 2025, 3, 2025, 3)
+		self.assertIn("Outside tenure", result["months"][0]["flags"])
+
 	def test_empty_months_omitted(self):
 		company = _make_company()
 		employee = _make_employee()

--- a/saral_hr/tests/test_data_cleansing.py
+++ b/saral_hr/tests/test_data_cleansing.py
@@ -252,3 +252,22 @@ class TestDataCleansing(FrappeTestCase):
 		result = dc.get_employee_month_matrix(cl, 2024, 1, 2024, 3)
 		labels = [r["month_label"] for r in result["months"]]
 		self.assertEqual(labels, ["Jan 2024"])
+
+	def test_whole_data_search_finds_orphan_month_outside_period(self):
+		"""Mistaken Mar-24 attendance is invisible in a 2025 period scan but found via all."""
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2025-01-01")
+		_make_attendance(cl, company, "2024-03-15")
+
+		period = dc.get_employee_month_matrix(
+			cl, 2025, 1, 2025, 8, scan_mode="period"
+		)
+		self.assertEqual(period["months"], [])
+
+		all_data = dc.get_employee_month_matrix(cl, scan_mode="all")
+		self.assertEqual(all_data["scan_mode"], "all")
+		labels = [r["month_label"] for r in all_data["months"]]
+		self.assertEqual(labels, ["Mar 2024"])
+		self.assertIn("Attendance only", all_data["months"][0]["flags"])
+		self.assertIn("Outside tenure", all_data["months"][0]["flags"])

--- a/saral_hr/tests/test_data_cleansing.py
+++ b/saral_hr/tests/test_data_cleansing.py
@@ -244,6 +244,31 @@ class TestDataCleansing(FrappeTestCase):
 			)
 		)
 
+	def test_pre_join_absent_fillers_not_flagged_outside_tenure(self):
+		"""Salary scaffolding Absents before joining must not raise Outside tenure."""
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-06-10")
+		_make_attendance(cl, company, "2024-06-01", status="Absent")
+		_make_attendance(cl, company, "2024-06-09", status="Absent")
+		_make_attendance(cl, company, "2024-06-10", status="Present")
+
+		result = dc.get_employee_month_matrix(cl, 2024, 6, 2024, 6)
+		self.assertEqual(len(result["months"]), 1)
+		row = result["months"][0]
+		self.assertNotIn("Outside tenure", row["flags"])
+		self.assertGreater(row["expected_days"], 0)
+
+	def test_present_before_joining_still_flagged_outside_tenure(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-06-10")
+		_make_attendance(cl, company, "2024-06-05", status="Present")
+		_make_attendance(cl, company, "2024-06-10", status="Present")
+
+		result = dc.get_employee_month_matrix(cl, 2024, 6, 2024, 6)
+		self.assertIn("Outside tenure", result["months"][0]["flags"])
+
 	def test_empty_months_omitted(self):
 		company = _make_company()
 		employee = _make_employee()

--- a/saral_hr/tests/test_data_cleansing.py
+++ b/saral_hr/tests/test_data_cleansing.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026, sj and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import getdate
+
+from saral_hr.saral_hr.page.data_cleansing import data_cleansing as dc
+
+
+def _uid() -> str:
+	return frappe.generate_hash(length=6)
+
+
+def _ensure_category(name: str = "Staff"):
+	if frappe.db.exists("Category", name):
+		return name
+	doc = frappe.get_doc({"doctype": "Category", "category": name, "has_subtype": 0})
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_company() -> str:
+	uid = _uid()
+	doc = frappe.get_doc(
+		{
+			"doctype": "Company",
+			"company": f"_Test DC {uid}",
+			"abbr": f"D{uid}"[:8],
+			"country": "India",
+			"default_currency": "INR",
+			"salary_calculation_based_on": "Exclude Weekly Offs (Working Days)",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_employee() -> str:
+	doc = frappe.get_doc(
+		{
+			"doctype": "Employee",
+			"naming_series": "HR-EMP-",
+			"first_name": f"DCEmp{_uid()}",
+			"gender": "Other",
+			"date_of_birth": "1990-01-01",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_company_link(employee: str, company: str, joining, left=None):
+	doc = frappe.get_doc(
+		{
+			"doctype": "Company Link",
+			"employee": employee,
+			"company": company,
+			"category": _ensure_category(),
+			"date_of_joining": getdate(joining),
+			"left_date": getdate(left) if left else None,
+			"is_active": 1,
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_attendance(cl: str, company: str, attendance_date: str, status: str = "Present"):
+	doc = frappe.get_doc(
+		{
+			"doctype": "Attendance",
+			"naming_series": "HR-ATT-.YYYY.-",
+			"employee": cl,
+			"company": company,
+			"attendance_date": attendance_date,
+			"status": status,
+		}
+	)
+	doc.flags.ignore_validate = True
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _stub_slip(cl: str, company: str, start_date: str, docstatus: int = 0) -> str:
+	name = f"SS-DC-{_uid()}"
+	end = getdate(start_date).replace(day=28)
+	frappe.get_doc(
+		{
+			"doctype": "Salary Slip",
+			"name": name,
+			"naming_series": "SS-.YYYY.-",
+			"employee": cl,
+			"employee_name": "DC Test",
+			"company": company,
+			"start_date": start_date,
+			"end_date": str(end),
+			"docstatus": docstatus,
+			"currency": "INR",
+		}
+	).db_insert()
+	return name
+
+
+class TestDataCleansing(FrappeTestCase):
+	def test_matrix_includes_outside_tenure_months_with_data(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-03-01")
+		# Attendance before joining
+		_make_attendance(cl, company, "2024-01-15")
+		# Attendance in tenure
+		_make_attendance(cl, company, "2024-03-10")
+
+		result = dc.get_employee_month_matrix(cl, 2024, 1, 2024, 3)
+		months = {r["month_label"]: r for r in result["months"]}
+		self.assertIn("Jan 2024", months)
+		self.assertIn("Mar 2024", months)
+		self.assertIn("Outside tenure", months["Jan 2024"]["flags"])
+		self.assertEqual(months["Jan 2024"]["expected_days"], 0)
+		self.assertGreater(months["Mar 2024"]["expected_days"], 0)
+
+	def test_flags_attendance_only_and_slip_only(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-01-01")
+		_make_attendance(cl, company, "2024-02-05")
+		_stub_slip(cl, company, "2024-03-01", docstatus=0)
+
+		result = dc.get_employee_month_matrix(cl, 2024, 2, 2024, 3)
+		by_m = {r["month"]: r for r in result["months"]}
+		self.assertIn("Attendance only", by_m[2]["flags"])
+		self.assertIn("Slip only", by_m[3]["flags"])
+		self.assertIn("Draft slip", by_m[3]["flags"])
+
+	def test_partial_coverage_flag(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-04-01")
+		_make_attendance(cl, company, "2024-04-02")
+		_make_attendance(cl, company, "2024-04-03")
+
+		result = dc.get_employee_month_matrix(cl, 2024, 4, 2024, 4)
+		self.assertEqual(len(result["months"]), 1)
+		row = result["months"][0]
+		self.assertEqual(row["attendance_days"], 2)
+		self.assertEqual(row["expected_days"], 30)
+		self.assertIn("Partial coverage", row["flags"])
+		self.assertEqual(row["coverage"], "Partial")
+
+	def test_attendance_delete_blocked_when_any_slip_exists(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-05-01")
+		_make_attendance(cl, company, "2024-05-10")
+		_stub_slip(cl, company, "2024-05-01", docstatus=0)
+
+		with self.assertRaises(frappe.ValidationError):
+			dc.delete_attendance(cl, year=2024, month=5)
+
+		# Cancelled also blocks
+		frappe.db.set_value("Salary Slip", frappe.db.get_value("Salary Slip", {"employee": cl}, "name"), "docstatus", 2)
+		with self.assertRaises(frappe.ValidationError):
+			dc.delete_attendance(cl, year=2024, month=5)
+
+	def test_attendance_delete_succeeds_after_slip_removed(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-06-01")
+		a1 = _make_attendance(cl, company, "2024-06-01")
+		a2 = _make_attendance(cl, company, "2024-06-02")
+		slip = _stub_slip(cl, company, "2024-06-01", docstatus=0)
+
+		with self.assertRaises(frappe.ValidationError):
+			dc.delete_attendance(cl, year=2024, month=6)
+
+		dc.delete_salary_slip(slip)
+		result = dc.delete_attendance(cl, year=2024, month=6)
+		self.assertEqual(result["count"], 2)
+		self.assertFalse(frappe.db.exists("Attendance", a1))
+		self.assertFalse(frappe.db.exists("Attendance", a2))
+		self.assertTrue(
+			frappe.db.exists(
+				"Data Cleansing Log",
+				{"employee": cl, "action": "delete_attendance"},
+			)
+		)
+
+	def test_delete_selected_attendance_days(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-07-01")
+		keep = _make_attendance(cl, company, "2024-07-01")
+		gone = _make_attendance(cl, company, "2024-07-02")
+
+		result = dc.delete_attendance(cl, names=[gone])
+		self.assertEqual(result["count"], 1)
+		self.assertTrue(frappe.db.exists("Attendance", keep))
+		self.assertFalse(frappe.db.exists("Attendance", gone))
+
+	def test_hr_user_cannot_mutate(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-08-01")
+		_make_attendance(cl, company, "2024-08-05")
+
+		# Create a disposable user with only Saral HR User
+		uid = _uid()
+		user = f"{uid}@dc.test"
+		if not frappe.db.exists("User", user):
+			u = frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": user,
+					"first_name": "DC User",
+					"send_welcome_email": 0,
+					"user_type": "System User",
+				}
+			)
+			u.insert(ignore_permissions=True)
+			u.add_roles("Saral HR User")
+
+		frappe.set_user(user)
+		try:
+			# View still works
+			matrix = dc.get_employee_month_matrix(cl, 2024, 8, 2024, 8)
+			self.assertFalse(matrix["can_mutate"])
+			with self.assertRaises(frappe.PermissionError):
+				dc.delete_attendance(cl, year=2024, month=8)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_delete_draft_slip_writes_log(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-09-01")
+		slip = _stub_slip(cl, company, "2024-09-01", docstatus=0)
+		out = dc.delete_salary_slip(slip)
+		self.assertEqual(out["deleted"], slip)
+		self.assertTrue(
+			frappe.db.exists(
+				"Data Cleansing Log",
+				{"employee": cl, "action": "delete_salary_slip"},
+			)
+		)
+
+	def test_empty_months_omitted(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company, "2024-01-01")
+		_make_attendance(cl, company, "2024-01-05")
+		result = dc.get_employee_month_matrix(cl, 2024, 1, 2024, 3)
+		labels = [r["month_label"] for r in result["months"]]
+		self.assertEqual(labels, ["Jan 2024"])

--- a/specs/007-data-cleansing.md
+++ b/specs/007-data-cleansing.md
@@ -28,12 +28,19 @@ Interactive Desk page **Data Cleansing**:
 | Filter | Type | Notes |
 |--------|------|--------|
 | Employee | Link → **Company Link** | Required |
-| From (year + month) | Select / Date parts | Required |
-| To (year + month) | Select / Date parts | Required; ≥ From |
+| Scan mode | Toggle | **Period scan** (From–To) or **Whole data search** (default) |
+| From (year + month) | Select / Date parts | Required only for Period scan |
+| To (year + month) | Select / Date parts | Required only for Period scan; ≥ From |
+
+**Whole data search** — lists every month that has any Attendance or Salary Slip for the employee (no date range). Use this to find mistaken orphans (e.g. only Mar-24 attendance) without guessing From–To.
+
+**Period scan** — same as before: only months inside From–To that have data.
 
 ### Month grid rows
 
-Show **every calendar month in [From, To] that has any Attendance or any Salary Slip** for that Company Link — including months **outside tenure** (that is how extras are found). Months with neither are omitted.
+- **Period scan:** every calendar month in [From, To] that has any Attendance or any Salary Slip.
+- **Whole data search:** every month with data across the employee’s entire history.
+- Including months **outside tenure**. Months with neither attendance nor slip are omitted.
 
 | Column | Definition |
 |--------|------------|
@@ -123,8 +130,8 @@ v2 reopen / grill before build: exact SSA delete rules, AS/AD interaction with s
 | # | Decision | Choice |
 |---|----------|--------|
 | 1 | Surface | Desk **Page** (interactive) |
-| 2 | Filters | Employee (Company Link) + **From–To month** |
-| 3 | Months shown | Any month in range with attendance **or** slip (incl. outside tenure) |
+| 2 | Filters | Employee (Company Link) + scan mode toggle + From–To for Period scan |
+| 3 | Months shown | Period: months in range with data. **All:** every month with attendance or slip (default UI) |
 | 4 | Flags | **All** five |
 | 5 | Attendance vs slip | Hard block attendance delete until **no** slip remains (any docstatus) |
 | 6 | Audit | DocType **Data Cleansing Log** |
@@ -132,6 +139,7 @@ v2 reopen / grill before build: exact SSA delete rules, AS/AD interaction with s
 | 8 | v1 scope | Attendance + Salary Slip only; AS/AD, SSA, company-wide orphans, period lock → **v2** |
 | 9 | Delete grain | Whole month **and** individual days |
 | 10 | Delete roles | Administrator / Saral HR Manager only; HR User view-only |
+| 11 | Scan modes | **Period scan** vs **Whole data search** (find orphans without knowing the month) |
 
 ## How?
 
@@ -139,11 +147,12 @@ v2 reopen / grill before build: exact SSA delete rules, AS/AD interaction with s
 
 Page module `saral_hr/saral_hr/page/data_cleansing/`:
 
-- `get_employee_month_matrix(employee, from_year, from_month, to_year, to_month)`
+- `get_employee_month_matrix(employee, …, scan_mode=period|all)`
 - `get_month_detail(employee, year, month)` — day list + slips
 - `delete_attendance(employee, names | month)` — enforces slip-absent rule + role
 - `cancel_salary_slip(name)` / `delete_salary_slip(name)` — role + write log
 - Permission helper: Manager / Admin / System Manager for mutating APIs; User can call read APIs
+- Whole-data discovery: distinct months from Attendance + Salary Slip (no range walk)
 
 Tenure for Expected / Outside tenure uses Company Link `date_of_joining` / `left_date` (same spirit as Attendance Dashboard).
 
@@ -162,6 +171,7 @@ Tenure for Expected / Outside tenure uses Company Link `date_of_joining` / `left
 ### Tests
 
 - Matrix includes outside-tenure months that have data
+- Whole data search finds months outside a narrow Period scan
 - Flags compute correctly for fixtures
 - Attendance delete blocked when Draft / Submitted / Cancelled slip exists
 - Attendance delete succeeds after slip removed
@@ -189,5 +199,5 @@ Tenure for Expected / Outside tenure uses Company Link `date_of_joining` / `left
 | Page stub | done (phase 0) |
 | Matrix API + UI | done |
 | Delete APIs + log DocType | done |
-| Tests | done (9) |
+| Tests | done (10) |
 | v2 features | planned (not started) |

--- a/specs/007-data-cleansing.md
+++ b/specs/007-data-cleansing.md
@@ -1,0 +1,193 @@
+# 007 — Data Cleansing
+
+| | |
+|---|---|
+| **Status** | planned |
+| **Branch** | `feat/data-cleansing` |
+| **Surface** | Desk page `data-cleansing` |
+| **Workspace** | Saral HR → card **Data Auditing and Cleansing** → link **Data Cleansing** |
+| **Primary sources** | `Company Link`, `Attendance`, `Salary Slip` |
+
+## Why?
+
+While entering historical attendance and payroll, HR users often mark months that were never paid, leave partial months, or leave draft/cancelled slips behind. Ops need one employee-scoped screen to **see which months have attendance and/or salary slips**, flag extras, and **delete wrong rows** (day or whole month) without hunting list views.
+
+## What?
+
+Interactive Desk page **Data Cleansing**:
+
+1. Select an employee (**Company Link**) and a **from month → to month** range.
+2. Show a **month grid** of attendance coverage + salary slip presence/status.
+3. Flag problem months (all flags below).
+4. Drill into a month: list attendance days + slip link.
+5. **Delete** wrong attendance (single days or whole month) and/or salary slips — with hard safety rules.
+6. Log every cleanse action to **Data Cleansing Log**.
+
+### Filters (v1)
+
+| Filter | Type | Notes |
+|--------|------|--------|
+| Employee | Link → **Company Link** | Required |
+| From (year + month) | Select / Date parts | Required |
+| To (year + month) | Select / Date parts | Required; ≥ From |
+
+### Month grid rows
+
+Show **every calendar month in [From, To] that has any Attendance or any Salary Slip** for that Company Link — including months **outside tenure** (that is how extras are found). Months with neither are omitted.
+
+| Column | Definition |
+|--------|------------|
+| Month | `MMM YYYY` |
+| Attendance days | Count of Attendance rows in month |
+| Expected days | Calendar days overlapping employment in that month (`0` if fully outside tenure) |
+| Coverage | Full / Partial / None / Outside tenure |
+| Slip | Slip name(s) or — |
+| Slip status | Draft / Submitted / Cancelled (multi if any odd case) |
+| Flags | See below |
+| Actions | View / Delete (role-gated) |
+
+### Flags (all in v1)
+
+| Flag | Meaning |
+|------|---------|
+| Attendance only | ≥1 attendance day, no slip of any status |
+| Slip only | Slip exists (any status), 0 attendance rows |
+| Outside tenure | Any attendance/slip date before joining or after left |
+| Partial coverage | Inside tenure and `0 < days < expected` |
+| Draft slip | At least one Draft slip for the month |
+
+### Delete rules (locked)
+
+**Roles**
+
+| Role | View | Delete |
+|------|------|--------|
+| Saral HR User | Yes | No |
+| Saral HR Manager | Yes | Yes |
+| Administrator / System Manager | Yes | Yes |
+
+**Attendance delete**
+
+- Allowed for **selected days** or **whole month**.
+- **Hard block** if **any** Salary Slip exists for that employee + month — Draft, Submitted, **or** Cancelled. Slip must be **absent** (deleted) first.
+- After slips are gone, Manager may delete attendance freely from this screen.
+
+**Salary Slip delete (from this screen, Manager+)**
+
+- **Draft** / **Cancelled**: delete allowed.
+- **Submitted**: cancel then delete (same screen flow; confirm). Cancelling uses standard slip `on_cancel` side effects.
+- Purpose: clear the month so attendance can then be removed.
+
+**Confirmations**
+
+- Always confirm with counts (e.g. “Delete 31 attendance rows for Feb 2024 for &lt;employee&gt;?”).
+- Slip cancel/delete confirms separately.
+
+### Audit log — Data Cleansing Log (DocType)
+
+Child/log DocType (or single DocType with rows) recording each cleanse:
+
+| Field | Notes |
+|-------|--------|
+| timestamp | |
+| user | |
+| employee | Company Link |
+| company | |
+| month_start | |
+| action | `delete_attendance` / `cancel_salary_slip` / `delete_salary_slip` |
+| reference_names | JSON / Small Text of deleted/cancelled doc names |
+| counts | e.g. attendance rows deleted |
+| reason | Optional Text (prompt if easy; can be empty in v1) |
+
+Only System Manager / Saral HR Manager need write via API; Users do not create logs manually.
+
+### Out of scope (v1) — confirmed
+
+v1 is **Attendance + Salary Slip** audit/delete only. Items below are deferred to **v2** (or a follow-on feature), not cancelled.
+
+### Feature scope — v2 (planned)
+
+Extend the same **Data Cleansing** surface (and **Data Cleansing Log**) with:
+
+| # | Feature | Intent |
+|---|---------|--------|
+| V2.1 | **Additional Salary / Additional Deduction cleanup** | Per employee + month range: list AS/AD docs, flag orphans (e.g. no slip / outside tenure / wrong month), allow Manager+ cancel/delete with same role gate and logging |
+| V2.2 | **SSA cleanup** | Surface Salary Structure Assignments that look wrong or unused for the selected employee/range (duplicates, gaps, assignments with no overlapping slips, outside tenure); Manager+ cancel/delete with hard rules TBD in a v2 grill |
+| V2.3 | **Company-wide orphan scan** | Company (+ optional From–To) mode: all employees at once — rows flagged Attendance only / Slip only / Outside tenure / Draft slip / (v2) AS·AD·SSA orphans; drill into employee month detail; bulk actions still Manager+ only |
+| V2.4 | **Period lock / freeze** | Separate later capability (may ship as its own spec under the Data Auditing and Cleansing card): lock a company month so attendance / slips / related docs cannot change without Admin unlock (+ optional password confirm). Complements cleansing — cleanse first, then freeze |
+
+v2 reopen / grill before build: exact SSA delete rules, AS/AD interaction with submitted slips, and whether period lock is a tab on this page or a distinct page/DocType.
+
+## Decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Surface | Desk **Page** (interactive) |
+| 2 | Filters | Employee (Company Link) + **From–To month** |
+| 3 | Months shown | Any month in range with attendance **or** slip (incl. outside tenure) |
+| 4 | Flags | **All** five |
+| 5 | Attendance vs slip | Hard block attendance delete until **no** slip remains (any docstatus) |
+| 6 | Audit | DocType **Data Cleansing Log** |
+| 7 | Workspace | New card **Data Auditing and Cleansing** → link **Data Cleansing** |
+| 8 | v1 scope | Attendance + Salary Slip only; AS/AD, SSA, company-wide orphans, period lock → **v2** |
+| 9 | Delete grain | Whole month **and** individual days |
+| 10 | Delete roles | Administrator / Saral HR Manager only; HR User view-only |
+
+## How?
+
+### Backend
+
+Page module `saral_hr/saral_hr/page/data_cleansing/`:
+
+- `get_employee_month_matrix(employee, from_year, from_month, to_year, to_month)`
+- `get_month_detail(employee, year, month)` — day list + slips
+- `delete_attendance(employee, names | month)` — enforces slip-absent rule + role
+- `cancel_salary_slip(name)` / `delete_salary_slip(name)` — role + write log
+- Permission helper: Manager / Admin / System Manager for mutating APIs; User can call read APIs
+
+Tenure for Expected / Outside tenure uses Company Link `date_of_joining` / `left_date` (same spirit as Attendance Dashboard).
+
+### Frontend
+
+- Filters → load matrix
+- Row click / View → drawer or panel with day checkboxes + slip actions
+- Delete buttons hidden for Saral HR User
+
+### Workspace
+
+- Card break label: **Data Auditing and Cleansing**
+- Link label: **Data Cleansing** → Page `data-cleansing`
+- Visible to existing Saral HR workspace roles (User + Manager); delete gated in page/API
+
+### Tests
+
+- Matrix includes outside-tenure months that have data
+- Flags compute correctly for fixtures
+- Attendance delete blocked when Draft / Submitted / Cancelled slip exists
+- Attendance delete succeeds after slip removed
+- HR User cannot call delete APIs
+- Manager delete writes Data Cleansing Log
+
+## Phases
+
+| Phase | Deliverable |
+|-------|-------------|
+| 0 | Spec + workspace card/link + page stub |
+| 1 | Read-only matrix + flags + month detail |
+| 2 | Slip cancel/delete from screen + log |
+| 3 | Attendance day/month delete (slip-absent gate) + log |
+| 4 | Unit tests + polish |
+| **v2** | AS/AD cleanup · SSA cleanup · company-wide orphan scan · period lock/freeze (grill + possibly split specs) |
+
+## Progress
+
+| Item | Status |
+|------|--------|
+| Spec drafted | done |
+| v2 scope documented | done |
+| Workspace card + link | done (phase 0) |
+| Page stub | done (phase 0) |
+| Matrix API + UI | pending |
+| Delete APIs + log DocType | pending |
+| Tests | pending |
+| v2 features | planned (not started) |

--- a/specs/007-data-cleansing.md
+++ b/specs/007-data-cleansing.md
@@ -59,7 +59,7 @@ Interactive Desk page **Data Cleansing**:
 |------|---------|
 | Attendance only | ≥1 attendance day, no slip of any status |
 | Slip only | Slip exists (any status), 0 attendance rows |
-| Outside tenure | Any attendance/slip date before joining or after left |
+| Outside tenure | Month fully outside employment with any data; **or** non-`Absent` attendance / any slip outside joining–left. Intentional pre-join / post-left **Absent** fillers in a tenure month are **not** flagged |
 | Partial coverage | Inside tenure and `0 < days < expected` |
 | Draft slip | At least one Draft slip for the month |
 
@@ -199,5 +199,5 @@ Tenure for Expected / Outside tenure uses Company Link `date_of_joining` / `left
 | Page stub | done (phase 0) |
 | Matrix API + UI | done |
 | Delete APIs + log DocType | done |
-| Tests | done (10) |
+| Tests | done (12) |
 | v2 features | planned (not started) |

--- a/specs/007-data-cleansing.md
+++ b/specs/007-data-cleansing.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | planned |
+| **Status** | in progress |
 | **Branch** | `feat/data-cleansing` |
 | **Surface** | Desk page `data-cleansing` |
 | **Workspace** | Saral HR → card **Data Auditing and Cleansing** → link **Data Cleansing** |
@@ -187,7 +187,7 @@ Tenure for Expected / Outside tenure uses Company Link `date_of_joining` / `left
 | v2 scope documented | done |
 | Workspace card + link | done (phase 0) |
 | Page stub | done (phase 0) |
-| Matrix API + UI | pending |
-| Delete APIs + log DocType | pending |
-| Tests | pending |
+| Matrix API + UI | done |
+| Delete APIs + log DocType | done |
+| Tests | done (9) |
 | v2 features | planned (not started) |

--- a/specs/007-data-cleansing.md
+++ b/specs/007-data-cleansing.md
@@ -59,7 +59,7 @@ Interactive Desk page **Data Cleansing**:
 |------|---------|
 | Attendance only | ≥1 attendance day, no slip of any status |
 | Slip only | Slip exists (any status), 0 attendance rows |
-| Outside tenure | Month fully outside employment with any data; **or** non-`Absent` attendance / any slip outside joining–left. Intentional pre-join / post-left **Absent** fillers in a tenure month are **not** flagged |
+| Outside tenure | Month fully outside employment with any data; **or** non-`Absent` attendance on dates outside joining–left. Not flagged: intentional pre-join/post-left **Absent** fillers; salary slips in a tenure-overlapping month (slip `start_date` is always the 1st) |
 | Partial coverage | Inside tenure and `0 < days < expected` |
 | Draft slip | At least one Draft slip for the month |
 
@@ -199,5 +199,5 @@ Tenure for Expected / Outside tenure uses Company Link `date_of_joining` / `left
 | Page stub | done (phase 0) |
 | Matrix API + UI | done |
 | Delete APIs + log DocType | done |
-| Tests | done (12) |
+| Tests | done (14) |
 | v2 features | planned (not started) |

--- a/specs/PROGRESS.md
+++ b/specs/PROGRESS.md
@@ -10,6 +10,7 @@ Single board for all specs in this folder. New specs get the next number (`002-â
 | 004 | [Monthly Salary Register (Old Format)](./004-monthly-salary-register.md) | done | Script Report + PDF/Excel; tests passing |
 | 005 | [Monthly Salary Register Compressed](./005-monthly-salary-register-compressed.md) | ready for review | Format filter + Desk/PDF/Excel UX polish |
 | 006 | [Additional-Only Salary Components](./006-additional-only-salary-components.md) | done | Link-only AS/AD; earnings_map by name; slip print; period lock = submitted slips |
+| 007 | [Data Cleansing](./007-data-cleansing.md) | planned | v1: employee attendance/slip audit+delete; v2: AS/AD, SSA, company orphans, period lock |
 
 ## Status legend
 

--- a/specs/PROGRESS.md
+++ b/specs/PROGRESS.md
@@ -10,7 +10,7 @@ Single board for all specs in this folder. New specs get the next number (`002-â
 | 004 | [Monthly Salary Register (Old Format)](./004-monthly-salary-register.md) | done | Script Report + PDF/Excel; tests passing |
 | 005 | [Monthly Salary Register Compressed](./005-monthly-salary-register-compressed.md) | ready for review | Format filter + Desk/PDF/Excel UX polish |
 | 006 | [Additional-Only Salary Components](./006-additional-only-salary-components.md) | done | Link-only AS/AD; earnings_map by name; slip print; period lock = submitted slips |
-| 007 | [Data Cleansing](./007-data-cleansing.md) | planned | v1: employee attendance/slip audit+delete; v2: AS/AD, SSA, company orphans, period lock |
+| 007 | [Data Cleansing](./007-data-cleansing.md) | in progress | v1 matrix+delete+log; v2 AS/AD, SSA, orphans, period lock |
 
 ## Status legend
 


### PR DESCRIPTION
## Why?
Historical attendance and salary data needs a way to audit mismatches and safely clean bad months/days before locking periods.

## What?
Desk page **Data Cleansing** (workspace card: Data Auditing and Cleansing) to flag attendance/slip issues per employee and delete months or days with audit logging.

## How?
- Matrix + detail APIs with flags (attendance only, slip only, outside tenure, partial coverage, draft slip)
- Hard-block attendance delete while any slip exists
- `Data Cleansing Log` DocType for audit trail
- Unit tests + Saral HR workspace link


Made with [Cursor](https://cursor.com)