### PR TITLE
fix: add Data Cleansing workspace link on migrate

### DIFF
--- a/saral_hr/patches.txt
+++ b/saral_hr/patches.txt
@@ -11,3 +11,4 @@ saral_hr.patches.clear_pt_special_component
 saral_hr.patches.migrate_pt_february_to_slabs
 saral_hr.patches.delete_broken_monthly_salary_register_report
 saral_hr.patches.seed_additional_only_salary_components
+saral_hr.patches.ensure_data_cleansing_workspace_link

--- a/saral_hr/patches/ensure_data_cleansing_workspace_link.py
+++ b/saral_hr/patches/ensure_data_cleansing_workspace_link.py
@@ -1,0 +1,91 @@
+import json
+
+import frappe
+
+CARD_NAME = "Data Auditing and Cleansing"
+LINK_LABEL = "Data Cleansing"
+PAGE_NAME = "data-cleansing"
+CARD_BLOCK_ID = "dcCard00001"
+
+
+def execute():
+	"""Ensure Saral HR workspace shows Data Cleansing (DB workspaces skip JSON sync)."""
+	if not frappe.db.exists("Workspace", "Saral HR"):
+		return
+
+	ws = frappe.get_doc("Workspace", "Saral HR")
+	changed = False
+
+	if not _has_data_cleansing_link(ws):
+		ws.append(
+			"links",
+			{
+				"type": "Card Break",
+				"label": CARD_NAME,
+				"hidden": 0,
+				"is_query_report": 0,
+				"link_count": 1,
+				"link_type": "DocType",
+				"onboard": 0,
+			},
+		)
+		ws.append(
+			"links",
+			{
+				"type": "Link",
+				"label": LINK_LABEL,
+				"link_type": "Page",
+				"link_to": PAGE_NAME,
+				"hidden": 0,
+				"is_query_report": 0,
+				"link_count": 0,
+				"onboard": 0,
+			},
+		)
+		changed = True
+
+	if _ensure_card_in_content(ws):
+		changed = True
+
+	if not changed:
+		return
+
+	ws.flags.ignore_links = True
+	ws.flags.ignore_permissions = True
+	ws.save(ignore_permissions=True)
+
+
+def _has_data_cleansing_link(ws) -> bool:
+	return any(
+		row.type == "Link" and row.label == LINK_LABEL and row.link_to == PAGE_NAME for row in ws.links
+	)
+
+
+def _ensure_card_in_content(ws) -> bool:
+	try:
+		blocks = json.loads(ws.content or "[]")
+	except (TypeError, json.JSONDecodeError):
+		return False
+
+	if any(
+		block.get("type") == "card" and block.get("data", {}).get("card_name") == CARD_NAME
+		for block in blocks
+	):
+		return False
+
+	card = {
+		"id": CARD_BLOCK_ID,
+		"type": "card",
+		"data": {"card_name": CARD_NAME, "col": 4},
+	}
+
+	# Place before Loan header when present; otherwise append.
+	insert_at = len(blocks)
+	for idx, block in enumerate(blocks):
+		if block.get("type") == "header" and "Loan" in (block.get("data", {}).get("text") or ""):
+			insert_at = idx
+			break
+
+	blocks.insert(insert_at, card)
+	ws.content = json.dumps(blocks)
+	return True

--- a/saral_hr/tests/test_ensure_data_cleansing_workspace_link.py
+++ b/saral_hr/tests/test_ensure_data_cleansing_workspace_link.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, sj and Contributors
+# See license.txt
+
+import json
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from saral_hr.patches.ensure_data_cleansing_workspace_link import (
+	CARD_NAME,
+	LINK_LABEL,
+	PAGE_NAME,
+	execute,
+)
+
+
+class TestEnsureDataCleansingWorkspaceLink(FrappeTestCase):
+	def test_adds_missing_card_and_link_idempotently(self):
+		if not frappe.db.exists("Workspace", "Saral HR"):
+			self.skipTest("Saral HR workspace not installed")
+
+		ws = frappe.get_doc("Workspace", "Saral HR")
+		ws.links = [row for row in ws.links if row.label not in (CARD_NAME, LINK_LABEL)]
+		blocks = json.loads(ws.content or "[]")
+		ws.content = json.dumps(
+			[
+				b
+				for b in blocks
+				if not (b.get("type") == "card" and b.get("data", {}).get("card_name") == CARD_NAME)
+			]
+		)
+		ws.flags.ignore_links = True
+		ws.save(ignore_permissions=True)
+
+		execute()
+		ws.reload()
+		self.assertTrue(
+			any(row.type == "Link" and row.label == LINK_LABEL and row.link_to == PAGE_NAME for row in ws.links)
+		)
+		content = json.loads(ws.content)
+		self.assertTrue(
+			any(
+				b.get("type") == "card" and b.get("data", {}).get("card_name") == CARD_NAME for b in content
+			)
+		)
+
+		link_count_before = sum(1 for row in ws.links if row.label == LINK_LABEL)
+		execute()
+		ws.reload()
+		link_count_after = sum(1 for row in ws.links if row.label == LINK_LABEL)
+		self.assertEqual(link_count_before, link_count_after)
+		self.assertEqual(link_count_after, 1)


### PR DESCRIPTION
## Problem
Data Cleansing appeared on the development site after a manual workspace DB sync, but production still misses the workspace card after deploy.

## Solution
Frappe skips re-importing Workspace JSON when the DB `modified` is newer than the file (typical on customized production workspaces). Add an idempotent migrate patch that inserts the **Data Auditing and Cleansing** card and **Data Cleansing** Page link if missing.


Made with [Cursor](https://cursor.com)