### PR TITLE
feat: percent of total earning salary deductions

### DIFF
--- a/saral_hr/saral_hr/doctype/salary_component/salary_component.js
+++ b/saral_hr/saral_hr/doctype/salary_component/salary_component.js
@@ -13,6 +13,7 @@ frappe.ui.form.on('Salary Component', {
         if (frm.doc.is_special_component) {
             ensure_all_months(frm);
         }
+        toggle_percent_lock(frm);
     },
 
     is_special_component(frm) {
@@ -24,9 +25,15 @@ frappe.ui.form.on('Salary Component', {
                     indicator: "orange",
                 });
             }
+            if (frm.doc.percent_on_total_earning) {
+                frm.set_value("percent_on_total_earning", 0);
+                frappe.show_alert({
+                    message: __("% on Total Earning was unchecked — it cannot combine with Special Component."),
+                    indicator: "orange",
+                });
+            }
             ensure_all_months(frm);
         } else {
-            // Clear the table when unchecked
             frm.clear_table("monthly_amounts");
             frm.refresh_field("monthly_amounts");
         }
@@ -42,9 +49,54 @@ frappe.ui.form.on('Salary Component', {
                 indicator: "orange",
             });
         }
+        if (frm.doc.is_additional_only && frm.doc.percent_on_total_earning) {
+            frm.set_value("percent_on_total_earning", 0);
+            frappe.show_alert({
+                message: __("% on Total Earning was unchecked — it cannot combine with Additional Only."),
+                indicator: "orange",
+            });
+        }
     },
 
-    // Only one payment-day mode may be active at a time
+    percent_on_total_earning(frm) {
+        if (!frm.doc.percent_on_total_earning) {
+            frm.set_value("percent_of_total_earning", 0);
+            return;
+        }
+        const clear = [];
+        if (frm.doc.depends_on_payment_days) {
+            frm.set_value("depends_on_payment_days", 0);
+            clear.push("Depends on Payment Days");
+        }
+        if (frm.doc.depends_on_physical_working_days) {
+            frm.set_value("depends_on_physical_working_days", 0);
+            clear.push("Depends on Physical Working Days");
+        }
+        if (frm.doc.daily_wage_component) {
+            frm.set_value("daily_wage_component", 0);
+            clear.push("Daily Wage Component");
+        }
+        if (frm.doc.is_special_component) {
+            frm.set_value("is_special_component", 0);
+            frm.clear_table("monthly_amounts");
+            frm.refresh_field("monthly_amounts");
+            clear.push("Is Special Component");
+        }
+        if (frm.doc.is_additional_only) {
+            frm.set_value("is_additional_only", 0);
+            clear.push("Is Additional Only");
+        }
+        if (frm.doc.employer_contribution) {
+            frm.set_value("employer_contribution", 0);
+            clear.push("Employer Contribution");
+        }
+        if (clear.length) {
+            frappe.show_alert({
+                message: __("Unchecked incompatible flags: {0}", [clear.join(", ")]),
+                indicator: "orange",
+            });
+        }
+    },
 
     depends_on_payment_days(frm) {
         if (frm.doc.depends_on_payment_days && frm.doc.depends_on_physical_working_days) {
@@ -52,6 +104,13 @@ frappe.ui.form.on('Salary Component', {
             frappe.show_alert({
                 message: __('Depends on Physical Working Days has been unchecked. A component can only have one calculation mode.'),
                 indicator: 'orange'
+            });
+        }
+        if (frm.doc.depends_on_payment_days && frm.doc.percent_on_total_earning) {
+            frm.set_value("percent_on_total_earning", 0);
+            frappe.show_alert({
+                message: __("% on Total Earning was unchecked — incompatible with payment-day proration."),
+                indicator: "orange",
             });
         }
     },
@@ -64,13 +123,58 @@ frappe.ui.form.on('Salary Component', {
                 indicator: 'orange'
             });
         }
+        if (frm.doc.depends_on_physical_working_days && frm.doc.percent_on_total_earning) {
+            frm.set_value("percent_on_total_earning", 0);
+            frappe.show_alert({
+                message: __("% on Total Earning was unchecked — incompatible with physical working days."),
+                indicator: "orange",
+            });
+        }
+    },
+
+    daily_wage_component(frm) {
+        if (frm.doc.daily_wage_component && frm.doc.percent_on_total_earning) {
+            frm.set_value("percent_on_total_earning", 0);
+            frappe.show_alert({
+                message: __("% on Total Earning was unchecked — incompatible with Daily Wage."),
+                indicator: "orange",
+            });
+        }
+    },
+
+    employer_contribution(frm) {
+        if (frm.doc.employer_contribution && frm.doc.percent_on_total_earning) {
+            frm.set_value("percent_on_total_earning", 0);
+            frappe.show_alert({
+                message: __("% on Total Earning was unchecked — incompatible with Employer Contribution."),
+                indicator: "orange",
+            });
+        }
     },
 });
 
-// ─────────────────────────────────────────────────────────────
-//  Ensure all 12 months exist in Jan→Dec order.
-//  Preserves amounts already entered by the user.
-// ─────────────────────────────────────────────────────────────
+function toggle_percent_lock(frm) {
+    if (frm.is_new() || !frm.doc.name) {
+        frm.set_df_property("percent_on_total_earning", "read_only", 0);
+        frm.set_df_property("percent_of_total_earning", "read_only", 0);
+        return;
+    }
+    frappe.call({
+        method: "saral_hr.saral_hr.doctype.salary_component.salary_component.is_percent_of_total_earning_locked",
+        args: { component_name: frm.doc.name },
+        callback(r) {
+            const locked = !!r.message;
+            frm.set_df_property("percent_on_total_earning", "read_only", locked ? 1 : 0);
+            frm.set_df_property("percent_of_total_earning", "read_only", locked ? 1 : 0);
+            if (locked) {
+                frm.dashboard.set_headline_alert(
+                    __("Percent is locked because this component is used on a Salary Structure Assignment."),
+                    "blue"
+                );
+            }
+        },
+    });
+}
 
 function ensure_all_months(frm) {
     const existing = {};
@@ -78,14 +182,12 @@ function ensure_all_months(frm) {
         if (r.month) existing[r.month] = r.amount || 0;
     });
 
-    // Check if all 12 months already present in correct order
     const current_months = (frm.doc.monthly_amounts || []).map(r => r.month);
     const already_ok = MONTHS.every((m, i) => current_months[i] === m)
         && current_months.length === 12;
 
     if (already_ok) return;
 
-    // Rebuild in Jan→Dec order preserving existing amounts
     frm.clear_table("monthly_amounts");
     MONTHS.forEach(month => {
         const row = frm.add_child("monthly_amounts");

--- a/saral_hr/saral_hr/doctype/salary_component/salary_component.json
+++ b/saral_hr/saral_hr/doctype/salary_component/salary_component.json
@@ -19,6 +19,8 @@
   "exclude_from_ctc",
   "is_special_component",
   "is_additional_only",
+  "percent_on_total_earning",
+  "percent_of_total_earning",
   "section_monthly_amounts",
   "monthly_amounts"
  ],
@@ -108,6 +110,22 @@
    "label": "Is Additional Only"
   },
   {
+   "default": "0",
+   "depends_on": "eval:doc.type == 'Deduction'",
+   "description": "When enabled, slip amount = Total Earnings × Percent (after attendance/proration, including Additional Salary). Mutually exclusive with payment-day, special, additional-only, and employer flags.",
+   "fieldname": "percent_on_total_earning",
+   "fieldtype": "Check",
+   "label": "% on Total Earning"
+  },
+  {
+   "depends_on": "eval:doc.percent_on_total_earning == 1",
+   "description": "Percent of slip Total Earnings (1–100). Locked once any Salary Structure Assignment references this component.",
+   "fieldname": "percent_of_total_earning",
+   "fieldtype": "Percent",
+   "label": "Percent of Total Earning",
+   "non_negative": 1
+  },
+  {
    "depends_on": "eval:doc.is_special_component == 1",
    "description": "Enter the fixed amount for each calendar month. Rows are pre-populated January to December. Amounts are applied as-is during payroll — no proration.",
    "fieldname": "section_monthly_amounts",
@@ -124,7 +142,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-08-07 00:00:00.000000",
+ "modified": "2026-08-11 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Saral Hr",
  "name": "Salary Component",

--- a/saral_hr/saral_hr/doctype/salary_component/salary_component.py
+++ b/saral_hr/saral_hr/doctype/salary_component/salary_component.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.utils import flt
 
 MONTHS = [
     "January", "February", "March", "April",
@@ -11,11 +12,32 @@ MONTHS = [
 ]
 
 
+@frappe.whitelist()
+def is_percent_of_total_earning_locked(component_name: str) -> bool:
+    """True when any non-cancelled SSA still references this component."""
+    if not component_name:
+        return False
+    return bool(frappe.db.sql(
+        """
+        SELECT 1
+        FROM `tabSalary Details` sd
+        INNER JOIN `tabSalary Structure Assignment` ssa ON ssa.name = sd.parent
+        WHERE sd.salary_component = %s
+          AND sd.parenttype = 'Salary Structure Assignment'
+          AND ssa.docstatus < 2
+        LIMIT 1
+        """,
+        (component_name,),
+    ))
+
+
 class SalaryComponent(Document):
 
     def validate(self):
         self._validate_calculation_flags()
         self._validate_additional_only()
+        self._validate_percent_of_total_earning()
+        self._validate_percent_lock()
         self._populate_monthly_amounts()
 
     def on_update(self):
@@ -39,6 +61,66 @@ class SalaryComponent(Document):
             frappe.throw(
                 "A component cannot be both <b>Is Special Component</b> and "
                 "<b>Is Additional Only</b>."
+            )
+
+    def _validate_percent_of_total_earning(self):
+        if not int(self.percent_on_total_earning or 0):
+            self.percent_of_total_earning = 0
+            return
+
+        if (self.type or "") != "Deduction":
+            frappe.throw(
+                "<b>% on Total Earning</b> is only allowed for Deduction components."
+            )
+
+        pct = flt(self.percent_of_total_earning)
+        if pct <= 0 or pct > 100:
+            frappe.throw(
+                "<b>Percent of Total Earning</b> must be greater than 0 and at most 100."
+            )
+
+        conflicts = []
+        if int(self.depends_on_payment_days or 0):
+            conflicts.append("Depends on Payment Days")
+        if int(self.depends_on_physical_working_days or 0):
+            conflicts.append("Depends on Physical Working Days")
+        if int(self.daily_wage_component or 0):
+            conflicts.append("Daily Wage Component")
+        if int(self.is_special_component or 0):
+            conflicts.append("Is Special Component")
+        if int(self.is_additional_only or 0):
+            conflicts.append("Is Additional Only")
+        if int(self.employer_contribution or 0):
+            conflicts.append("Employer Contribution")
+
+        if conflicts:
+            frappe.throw(
+                "<b>% on Total Earning</b> cannot be combined with: "
+                + ", ".join(f"<b>{c}</b>" for c in conflicts)
+                + "."
+            )
+
+    def _validate_percent_lock(self):
+        if self.is_new():
+            return
+        before = self.get_doc_before_save()
+        if not before:
+            return
+
+        check_changed = int(before.percent_on_total_earning or 0) != int(
+            self.percent_on_total_earning or 0
+        )
+        pct_changed = flt(before.percent_of_total_earning) != flt(
+            self.percent_of_total_earning
+        )
+        if not (check_changed or pct_changed):
+            return
+
+        if is_percent_of_total_earning_locked(self.name):
+            frappe.throw(
+                "Cannot change <b>% on Total Earning</b> or the percent while this "
+                "component is used on a Salary Structure Assignment. "
+                "Cancel or delete those assignments first."
             )
 
     # ──────────────────────────────────────────────
@@ -76,8 +158,8 @@ class SalaryComponent(Document):
 
     def _sync_flags_to_salary_details(self):
         """Push updated payment-day flags, daily_wage_component flag,
-        and exclude_from_ctc flag to every Salary Details row that
-        references this component."""
+        exclude_from_ctc, and percent-of-earning fields to every Salary Details
+        row that references this component."""
         try:
             existing_columns = set(frappe.db.get_table_columns("tabSalary Details"))
         except Exception:
@@ -94,6 +176,16 @@ class SalaryComponent(Document):
 
         if "exclude_from_ctc" in existing_columns:
             updates["exclude_from_ctc"] = self.exclude_from_ctc or 0
+
+        if "percent_on_total_earning" in existing_columns:
+            updates["percent_on_total_earning"] = self.percent_on_total_earning or 0
+
+        if "percent_of_total_earning" in existing_columns:
+            updates["percent_of_total_earning"] = (
+                flt(self.percent_of_total_earning)
+                if int(self.percent_on_total_earning or 0)
+                else 0
+            )
 
         if not updates:
             return

--- a/saral_hr/saral_hr/doctype/salary_details/salary_details.json
+++ b/saral_hr/saral_hr/doctype/salary_details/salary_details.json
@@ -12,6 +12,8 @@
   "amount",
   "base_amount",
   "per_day_rate",
+  "percent_of_total_earning",
+  "percent_on_total_earning",
   "depends_on_payment_days",
   "depends_on_physical_working_days",
   "daily_wage_component",
@@ -57,6 +59,24 @@
    "hidden": 1,
    "label": "Per Day Rate",
    "options": "currency"
+  },
+  {
+   "default": "0",
+   "fetch_from": "salary_component.percent_of_total_earning",
+   "fieldname": "percent_of_total_earning",
+   "fieldtype": "Percent",
+   "in_list_view": 1,
+   "label": "% of Total Earning",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fetch_from": "salary_component.percent_on_total_earning",
+   "fieldname": "percent_on_total_earning",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "% on Total Earning",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_snib",
@@ -119,7 +139,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-05-06 16:41:41.259897",
+ "modified": "2026-08-11 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Saral Hr",
  "name": "Salary Details",

--- a/saral_hr/saral_hr/doctype/salary_slip/salary_slip.js
+++ b/saral_hr/saral_hr/doctype/salary_slip/salary_slip.js
@@ -64,6 +64,14 @@ frappe.ui.form.on("Salary Slip", {
 });
 
 frappe.ui.form.on("Salary Details", {
+    form_render(frm, cdt, cdn) {
+        const row = locals[cdt][cdn];
+        if (!row || !cint(row.percent_on_total_earning)) return;
+        const grid = frm.fields_dict[row.parentfield] && frm.fields_dict[row.parentfield].grid;
+        if (!grid) return;
+        const grid_row = grid.grid_rows_by_docname[cdn];
+        if (grid_row) grid_row.toggle_editable("amount", false);
+    },
     amount(frm) { recalculate_salary(frm); },
     earnings_remove(frm) { recalculate_salary(frm); },
     deductions_remove(frm) { recalculate_salary(frm); },
@@ -444,10 +452,14 @@ function recalculate_salary(frm, wd_override, pd_override, phd_override) {
         const per_day_rate = flt(row.per_day_rate || 0);
         const statutory = is_statutory(row.salary_component);
         const pt = is_pt(row.salary_component);
+        const pct_on = parseInt(row.percent_on_total_earning || 0);
+        const pct = flt(row.percent_of_total_earning || 0);
 
         let amount;
 
-        if (pt) {
+        if (pct_on) {
+            amount = Math.max(total_earnings, 0) * pct / 100;
+        } else if (pt) {
             amount = slip_month === 2 ? 300 : 200;
         } else if (statutory) {
             amount = base;
@@ -466,6 +478,9 @@ function recalculate_salary(frm, wd_override, pd_override, phd_override) {
         }
 
         row.amount = round_salary_amount(frm, amount);
+        if (pct_on) {
+            row.base_amount = row.amount;
+        }
         total_deductions += row.amount;
 
         if ((row.salary_component || "").toLowerCase().includes("retention")) retention += row.amount;

--- a/saral_hr/saral_hr/doctype/salary_slip/salary_slip.py
+++ b/saral_hr/saral_hr/doctype/salary_slip/salary_slip.py
@@ -306,7 +306,8 @@ def get_salary_structure_for_employee(
             "Salary Component", comp_name,
             ["salary_component_abbr", "depends_on_payment_days",
              "depends_on_physical_working_days", "employer_contribution",
-             "type", "daily_wage_component"],
+             "type", "daily_wage_component",
+             "percent_on_total_earning", "percent_of_total_earning"],
             as_dict=True
         ) or {}
 
@@ -376,6 +377,8 @@ def get_salary_structure_for_employee(
         is_daily_wage = int(meta.get("daily_wage_component") or getattr(row, "daily_wage_component", 0) or 0)
         per_day_rate  = flt(getattr(row, "per_day_rate", None) or 0)
         amount        = flt(row.amount, amount_digits)
+        pct_on        = int(meta.get("percent_on_total_earning") or 0)
+        pct_val       = flt(meta.get("percent_of_total_earning") or 0)
         if _is_pt_component(row.salary_component):
             # Preview only — final PT is applied after gross in calculate_salary_slip_amounts_exact
             ssa_gross_est = sum(flt(r.amount) for r in (ssa_doc.earnings or []))
@@ -383,6 +386,9 @@ def get_salary_structure_for_employee(
                 _company_pt_amount(ssa_doc.company, ssa_gross_est, employee, start_date),
                 amount_digits,
             )
+        elif pct_on:
+            # Preview from SSA amount; final amount from slip total_earnings after Additional Salary
+            amount = flt(row.amount, amount_digits)
         deductions.append({
             "salary_component":                 row.salary_component,
             "abbr":                             meta.get("salary_component_abbr") or getattr(row, "abbr", "") or "",
@@ -391,8 +397,10 @@ def get_salary_structure_for_employee(
             "per_day_rate":                     per_day_rate,
             "daily_wage_component":             is_daily_wage,
             "employer_contribution":            0,
-            "depends_on_payment_days":          int(meta.get("depends_on_payment_days") or 0),
-            "depends_on_physical_working_days": int(meta.get("depends_on_physical_working_days") or 0),
+            "depends_on_payment_days":          0 if pct_on else int(meta.get("depends_on_payment_days") or 0),
+            "depends_on_physical_working_days": 0 if pct_on else int(meta.get("depends_on_physical_working_days") or 0),
+            "percent_on_total_earning":         pct_on,
+            "percent_of_total_earning":         pct_val if pct_on else 0,
         })
 
     for row in (ssa_doc.employer_share or []):
@@ -525,8 +533,16 @@ def calculate_salary_slip_amounts_exact(
         is_daily_wage = int(getattr(row, "daily_wage_component", 0) or 0)
         per_day_rate  = flt(getattr(row, "per_day_rate", 0) or 0)
         is_pt         = _is_pt_component(row.salary_component)
+        pct_meta      = _percent_of_total_earning_meta(row.salary_component)
 
-        if is_pt:
+        if int(pct_meta.get("percent_on_total_earning") or 0):
+            pct = flt(pct_meta.get("percent_of_total_earning") or 0)
+            if hasattr(row, "percent_on_total_earning"):
+                row.percent_on_total_earning = 1
+            if hasattr(row, "percent_of_total_earning"):
+                row.percent_of_total_earning = pct
+            amount = max(flt(total_earnings), 0.0) * pct / 100.0
+        elif is_pt:
             amount = _company_pt_amount(company, total_earnings, salary_slip.employee, start_date)
         elif _is_statutory_component(row.salary_component):
             amount = base
@@ -540,6 +556,8 @@ def calculate_salary_slip_amounts_exact(
             amount = base
 
         row.amount        = flt(amount, digits)
+        if int(pct_meta.get("percent_on_total_earning") or 0):
+            row.base_amount = row.amount
         total_deductions += row.amount
         if "retention" in (row.salary_component or "").lower():
             retention += row.amount
@@ -576,6 +594,17 @@ def _is_da_component(comp_name, abbr):
         a.startswith("da-") or a.startswith("da ") or
         a == "da - dr" or a.startswith("da-dr")
     )
+
+
+def _percent_of_total_earning_meta(comp_name):
+    if not comp_name:
+        return {}
+    return frappe.db.get_value(
+        "Salary Component",
+        comp_name,
+        ["percent_on_total_earning", "percent_of_total_earning"],
+        as_dict=True,
+    ) or {}
 
 
 MONTHS_LIST = [
@@ -1453,6 +1482,8 @@ def bulk_generate_salary_slips(employees, year, month):
                 r.daily_wage_component             = int(src.get('daily_wage_component', 0))
                 r.depends_on_payment_days          = int(src.get('depends_on_payment_days', 0))
                 r.depends_on_physical_working_days = int(src.get('depends_on_physical_working_days', 0))
+                r.percent_on_total_earning         = int(src.get('percent_on_total_earning', 0))
+                r.percent_of_total_earning         = flt(src.get('percent_of_total_earning', 0))
                 if extra is not None: r.employer_contribution = extra
 
             for e in sd.get('earnings', []):       _append_row('earnings', e)

--- a/saral_hr/saral_hr/doctype/salary_slip/test_percent_of_total_earning.py
+++ b/saral_hr/saral_hr/doctype/salary_slip/test_percent_of_total_earning.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2026, sj and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import flt
+
+from saral_hr.saral_hr.doctype.salary_component.salary_component import (
+	is_percent_of_total_earning_locked,
+)
+from saral_hr.saral_hr.doctype.salary_slip.salary_slip import (
+	calculate_salary_slip_amounts_exact,
+)
+
+
+def _uid() -> str:
+	return frappe.generate_hash(length=6)
+
+
+def _ensure_component(name, abbr, type_="Deduction", **extra):
+	if frappe.db.exists("Salary Component", name):
+		doc = frappe.get_doc("Salary Component", name)
+		doc.update(extra)
+		doc.save(ignore_permissions=True)
+		return doc.name
+	doc = frappe.get_doc(
+		{
+			"doctype": "Salary Component",
+			"salary_component": name,
+			"salary_component_abbr": abbr,
+			"type": type_,
+			**extra,
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_company() -> str:
+	uid = _uid()
+	doc = frappe.get_doc(
+		{
+			"doctype": "Company",
+			"company": f"_Test PctEarn {uid}",
+			"abbr": f"P{uid}"[:8],
+			"country": "India",
+			"default_currency": "INR",
+			"salary_calculation_based_on": "Exclude Weekly Offs (Working Days)",
+			"salary_amount_rounding_digits": "2",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_employee() -> str:
+	doc = frappe.get_doc(
+		{
+			"doctype": "Employee",
+			"naming_series": "HR-EMP-",
+			"first_name": f"Pct{_uid()}",
+			"gender": "Other",
+			"date_of_birth": "1990-01-01",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _ensure_category(name: str = "Staff"):
+	if frappe.db.exists("Category", name):
+		return name
+	doc = frappe.get_doc({"doctype": "Category", "category": name, "has_subtype": 0})
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _make_company_link(employee: str, company: str):
+	doc = frappe.get_doc(
+		{
+			"doctype": "Company Link",
+			"employee": employee,
+			"company": company,
+			"category": _ensure_category(),
+			"date_of_joining": "2024-01-01",
+			"weekly_off": "Sunday",
+			"is_active": 1,
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+class TestPercentOfTotalEarning(FrappeTestCase):
+	def test_slip_percent_includes_additional_salary_row(self):
+		"""50k earnings + 5k additional on earnings table → 10% = 5500."""
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company)
+		uid = _uid()
+		basic = _ensure_component(f"Basic Pct {uid}", f"B{uid}", "Earning")
+		tds = _ensure_component(
+			f"94J {uid}",
+			f"J{uid}",
+			"Deduction",
+			percent_on_total_earning=1,
+			percent_of_total_earning=10,
+		)
+		addl = _ensure_component(f"Prod Inc {uid}", f"PI{uid}", "Earning", is_additional_only=1)
+
+		ss = frappe.new_doc("Salary Slip")
+		ss.employee = cl
+		ss.company = company
+		ss.start_date = "2024-01-01"
+		ss.end_date = "2024-01-31"
+		ss.total_working_days = 30
+		ss.payment_days = 30
+		ss.physical_working_days = 30
+
+		e = ss.append("earnings", {})
+		e.salary_component = basic
+		e.base_amount = 50000
+		e.amount = 50000
+
+		a = ss.append("earnings", {})
+		a.salary_component = addl
+		a.base_amount = 5000
+		a.amount = 5000
+
+		d = ss.append("deductions", {})
+		d.salary_component = tds
+		d.base_amount = 0
+		d.amount = 0
+		d.percent_on_total_earning = 1
+		d.percent_of_total_earning = 10
+
+		calculate_salary_slip_amounts_exact(ss, 0, "2024-01-01")
+		self.assertEqual(flt(ss.total_earnings), 55000)
+		self.assertEqual(flt(ss.deductions[0].amount), 5500)
+
+	def test_two_percent_components(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company)
+		uid = _uid()
+		basic = _ensure_component(f"Basic Two {uid}", f"BT{uid}", "Earning")
+		c10 = _ensure_component(
+			f"94J Two {uid}", f"J2{uid}", "Deduction",
+			percent_on_total_earning=1, percent_of_total_earning=10,
+		)
+		c2 = _ensure_component(
+			f"91Q Two {uid}", f"Q2{uid}", "Deduction",
+			percent_on_total_earning=1, percent_of_total_earning=2,
+		)
+
+		ss = frappe.new_doc("Salary Slip")
+		ss.employee = cl
+		ss.company = company
+		ss.start_date = "2024-01-01"
+		ss.end_date = "2024-01-31"
+		ss.total_working_days = 30
+		ss.payment_days = 30
+		ss.physical_working_days = 30
+		e = ss.append("earnings", {})
+		e.salary_component = basic
+		e.base_amount = 50000
+		e.amount = 50000
+		for name, pct in ((c10, 10), (c2, 2)):
+			d = ss.append("deductions", {})
+			d.salary_component = name
+			d.percent_on_total_earning = 1
+			d.percent_of_total_earning = pct
+			d.amount = 0
+			d.base_amount = 0
+
+		calculate_salary_slip_amounts_exact(ss, 0, "2024-01-01")
+		by_name = {r.salary_component: flt(r.amount) for r in ss.deductions}
+		self.assertEqual(by_name[c10], 5000)
+		self.assertEqual(by_name[c2], 1000)
+
+	def test_zero_earnings_yields_zero(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company)
+		uid = _uid()
+		tds = _ensure_component(
+			f"94J Zero {uid}", f"JZ{uid}", "Deduction",
+			percent_on_total_earning=1, percent_of_total_earning=10,
+		)
+		ss = frappe.new_doc("Salary Slip")
+		ss.employee = cl
+		ss.company = company
+		ss.start_date = "2024-01-01"
+		ss.end_date = "2024-01-31"
+		ss.total_working_days = 30
+		ss.payment_days = 0
+		ss.physical_working_days = 0
+		d = ss.append("deductions", {})
+		d.salary_component = tds
+		d.percent_on_total_earning = 1
+		d.percent_of_total_earning = 10
+		d.amount = 999
+		d.base_amount = 999
+		calculate_salary_slip_amounts_exact(ss, 0, "2024-01-01")
+		self.assertEqual(flt(ss.deductions[0].amount), 0)
+
+	def test_mutual_exclusion_with_payment_days(self):
+		uid = _uid()
+		doc = frappe.get_doc(
+			{
+				"doctype": "Salary Component",
+				"salary_component": f"Bad Pct {uid}",
+				"salary_component_abbr": f"BP{uid}",
+				"type": "Deduction",
+				"percent_on_total_earning": 1,
+				"percent_of_total_earning": 10,
+				"depends_on_payment_days": 1,
+			}
+		)
+		self.assertRaises(frappe.ValidationError, doc.insert)
+
+	def test_percent_lock_on_ssa(self):
+		company = _make_company()
+		employee = _make_employee()
+		cl = _make_company_link(employee, company)
+		uid = _uid()
+		basic = _ensure_component(f"Basic Lock {uid}", f"BL{uid}", "Earning")
+		tds = _ensure_component(
+			f"94J Lock {uid}", f"JL{uid}", "Deduction",
+			percent_on_total_earning=1, percent_of_total_earning=10,
+		)
+		structure = frappe.get_doc(
+			{
+				"doctype": "Salary Structure",
+				"salary_structure_name": f"SS Pct {uid}",
+				"company": company,
+				"currency": "INR",
+				"is_active": "Yes",
+			}
+		)
+		structure.append("earnings", {"salary_component": basic, "amount": 50000})
+		structure.append("deductions", {"salary_component": tds, "amount": 0})
+		structure.insert(ignore_permissions=True)
+
+		ssa = frappe.get_doc(
+			{
+				"doctype": "Salary Structure Assignment",
+				"employee": cl,
+				"company": company,
+				"from_date": "2024-01-01",
+				"to_date": "2024-12-31",
+				"salary_structure": structure.name,
+				"currency": "INR",
+			}
+		)
+		ssa.append("earnings", {"salary_component": basic, "amount": 50000})
+		ssa.append(
+			"deductions",
+			{
+				"salary_component": tds,
+				"amount": 5000,
+				"percent_on_total_earning": 1,
+				"percent_of_total_earning": 10,
+			},
+		)
+		ssa.insert(ignore_permissions=True)
+
+		self.assertTrue(is_percent_of_total_earning_locked(tds))
+		comp = frappe.get_doc("Salary Component", tds)
+		comp.percent_of_total_earning = 5
+		self.assertRaises(frappe.ValidationError, comp.save)
+
+		# Draft SSA: delete unlocks (cancel requires submit first)
+		ssa.delete()
+		self.assertFalse(is_percent_of_total_earning_locked(tds))
+		comp.reload()
+		comp.percent_of_total_earning = 5
+		comp.save(ignore_permissions=True)
+		self.assertEqual(flt(comp.percent_of_total_earning), 5)

--- a/saral_hr/saral_hr/doctype/salary_structure/salary_structure.js
+++ b/saral_hr/saral_hr/doctype/salary_structure/salary_structure.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("Salary Structure", {
     refresh(frm) {
-        // No totals calculation
+        // No totals calculation — % components keep Amount at 0
     }
 });
 
@@ -19,26 +19,48 @@ frappe.ui.form.on("Salary Details", {
     salary_component: function(frm, cdt, cdn) {
         let row = locals[cdt][cdn];
 
-        if (row.salary_component) {
-            frappe.call({
-                method: "frappe.client.get",
-                args: {
-                    doctype: "Salary Component",
-                    name: row.salary_component
-                },
-                callback: function(r) {
-                    if (r.message) {
-                        frappe.model.set_value(
-                            cdt,
-                            cdn,
-                            "abbr",
-                            r.message.salary_component_abbr
-                        );
-                    }
+        if (!row.salary_component) return;
+
+        frappe.db.get_value(
+            "Salary Component",
+            row.salary_component,
+            [
+                "salary_component_abbr",
+                "percent_on_total_earning",
+                "percent_of_total_earning",
+            ],
+            (r) => {
+                if (!r) return;
+                frappe.model.set_value(cdt, cdn, "abbr", r.salary_component_abbr || "");
+                frappe.model.set_value(
+                    cdt,
+                    cdn,
+                    "percent_on_total_earning",
+                    cint(r.percent_on_total_earning)
+                );
+                frappe.model.set_value(
+                    cdt,
+                    cdn,
+                    "percent_of_total_earning",
+                    flt(r.percent_of_total_earning)
+                );
+                if (cint(r.percent_on_total_earning) && row.parentfield === "deductions") {
+                    frappe.model.set_value(cdt, cdn, "amount", 0);
+                    frappe.model.set_value(cdt, cdn, "base_amount", 0);
                 }
-            });
-        }
-    }
+            }
+        );
+    },
+
+    form_render(frm, cdt, cdn) {
+        if (frm.doctype !== "Salary Structure") return;
+        const row = locals[cdt][cdn];
+        if (!row || !cint(row.percent_on_total_earning)) return;
+        const grid = frm.fields_dict[row.parentfield] && frm.fields_dict[row.parentfield].grid;
+        if (!grid) return;
+        const grid_row = grid.grid_rows_by_docname[cdn];
+        if (grid_row) grid_row.toggle_editable("amount", false);
+    },
 });
 
 function set_salary_component_filter(frm, cdt, cdn, component_type) {

--- a/saral_hr/saral_hr/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/saral_hr/saral_hr/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -142,6 +142,12 @@ frappe.ui.form.on("Salary Details", {
     amount(frm, cdt, cdn) {
         const row = frappe.get_doc(cdt, cdn);
 
+        if (cint(row.percent_on_total_earning) && row.parentfield === "deductions") {
+            // Amount is derived from SSA gross × % — restore computed value
+            _apply_percent_of_total_earning_amounts(frm);
+            return;
+        }
+
         if (frm._locked_vda_row
             && row
             && row.name === frm._locked_vda_row
@@ -173,6 +179,15 @@ frappe.ui.form.on("Salary Details", {
         }
 
         setTimeout(() => calculate_salary(frm), 50);
+    },
+    form_render(frm, cdt, cdn) {
+        const row = locals[cdt][cdn];
+        if (!row || !cint(row.percent_on_total_earning)) return;
+        if (frm.doctype !== "Salary Structure Assignment" && frm.doctype !== "Salary Structure") return;
+        const grid = frm.fields_dict[row.parentfield] && frm.fields_dict[row.parentfield].grid;
+        if (!grid) return;
+        const grid_row = grid.grid_rows_by_docname[cdn];
+        if (grid_row) grid_row.toggle_editable("amount", false);
     },
     salary_details_remove(frm, cdt, cdn) {
         _calculate_excluding_row(frm, cdn);
@@ -1078,6 +1093,7 @@ function _sum_basic_da_excluding(frm, excluded_cdn) {
 
 function _do_calculate(frm, silent) {
     if (frm.doc.docstatus === 1) return;
+    _apply_percent_of_total_earning_amounts(frm);
     const gross       = flt(_sum_earnings(frm), 2);
     let emp_ded       = 0;
     let empr_cont     = 0;
@@ -1122,6 +1138,24 @@ function _sum_earnings(frm) {
     let t = 0;
     (frm.doc.earnings || []).forEach(r => { t += flt(r.amount); });
     return t;
+}
+
+function _apply_percent_of_total_earning_amounts(frm) {
+    const gross = flt(_sum_earnings(frm), 2);
+    let changed = false;
+    (frm.doc.deductions || []).forEach(row => {
+        if (!cint(row.percent_on_total_earning)) return;
+        const pct = flt(row.percent_of_total_earning);
+        const amount = flt(Math.max(gross, 0) * pct / 100, 2);
+        if (flt(row.amount) !== amount) {
+            row.amount = amount;
+            row.base_amount = amount;
+            changed = true;
+        }
+    });
+    if (changed) {
+        frm.refresh_field("deductions");
+    }
 }
 
 function _sum_basic_da(frm) {

--- a/specs/009-percent-of-total-earning.md
+++ b/specs/009-percent-of-total-earning.md
@@ -1,0 +1,141 @@
+# 009 — Percent of Total Earning Deductions
+
+| | |
+|---|---|
+| **Status** | in progress |
+| **Branch** | `feat/percent-of-total-earning` |
+| **Primary DocTypes** | Salary Component, Salary Details, Salary Structure, Salary Structure Assignment, Salary Slip |
+| **Grilled** | 2026-08-11 |
+
+## Why?
+
+HR needs deductions like **94J @ 10%** and **91Q @ 2%** of **Total Earnings**, without a formula engine. Each rate belongs on its own Salary Component so users can add as many as they need and attach them via Structure → SSA.
+
+## What?
+
+1. Salary Component: **`% on Total Earning`** + **percent** (1–100).
+2. Multiple such deductions allowed on the same slip; each uses its own %.
+3. **Slip (authoritative):** after attendance/proration earnings (including Additional Salary) → `amount = max(0, total_earnings) × percent / 100`, rounded with company digits.
+4. **SSA (preview):** read-only % + amount from SSA gross × % (preview ≠ final OK).
+5. **Structure:** read-only %; Amount stays `0`.
+6. Lock % + checkbox once any non-cancelled SSA references the component; unlock when none remain.
+
+### Out of scope (v1)
+
+| Deferred | Notes |
+|----------|--------|
+| CTC Calculator | No change |
+| Income Tax / TDS reports | Afterwards |
+| Seed components | Users create 94J / 91Q themselves |
+| Tax slabs / regimes / exemptions | Flat % only |
+| Period-versioned % (like ESIC/PF periods) | Single % on component + SSA lock |
+
+## Decisions (locked)
+
+| # | Topic | Decision |
+|---|--------|----------|
+| 1 | Source of truth for rate | **Salary Component** (`%` + checkbox) |
+| 2 | Applicability | Component on Structure → SSA → appears on slip |
+| 3 | Slip base | `total_earnings` after proration **including Additional Salary** |
+| 4 | Timing | After earnings finalized (same phase as PT), before net |
+| 5 | Mutual exclusion | Forbidden with: payment days, physical WD, daily wage, special, additional-only, employer contribution |
+| 6 | Type | Deduction only |
+| 7 | SSA Amount | Read-only preview = SSA earnings sum × % |
+| 8 | SSA % display | Read-only, from component |
+| 9 | Structure Amount | `0`; show read-only % only |
+| 10 | Preview ≠ final | OK |
+| 11 | Rate lock | Lock **%** and **checkbox** when any SSA (draft or submitted) references component |
+| 12 | Unlock | When all such SSAs are **deleted** or **cancelled** |
+| 13 | Editable while locked | Name, abbr, description OK |
+| 14 | Zero / negative earnings | Amount = **0** |
+| 15 | Rounding | Company `salary_amount_rounding_digits` |
+| 16 | Percent validation | Required when checked; `> 0` and `≤ 100` |
+| 17 | Slip Amount | **Read-only**; no manual override |
+| 18 | Client slip JS | Must mirror server calc |
+| 19 | Seeds | None |
+| 20 | Reports / CTC | Out of scope |
+
+## Fields
+
+### Salary Component
+
+| Fieldname | Type | Default | Notes |
+|-----------|------|---------|--------|
+| `percent_on_total_earning` | Check | 0 | Label: **% on Total Earning**; `depends_on: type == Deduction` |
+| `percent_of_total_earning` | Percent | | Label: **Percent of Total Earning**; shown when check on; 0–100 |
+
+Validation:
+- If check on → type must be Deduction; percent in (0, 100]; clear conflicting flags (or throw).
+- If check off → clear percent (or ignore).
+- If locked by SSA → reject change to check / percent.
+
+### Salary Details (child)
+
+| Fieldname | Type | Notes |
+|-----------|------|--------|
+| `percent_of_total_earning` | Percent | `fetch_from` component; read-only; in list view useful on SSA |
+
+`amount` read-only in UI when parent row’s component has `percent_on_total_earning`.
+
+## How?
+
+### 1. Component validate + lock helper
+
+- Mutual exclusion with existing flags (extend `_validate_calculation_flags` / additional-only checks).
+- `component_percent_locked(name)` → exists Salary Details row under Salary Structure Assignment where `docstatus != 2` and `salary_component = name`.
+
+### 2. SSA JS
+
+- On earnings amount change / component add: for each %-deduction row, set amount = `gross_salary × percent / 100` (company digits if available).
+- Make amount + percent read-only for those rows.
+
+### 3. Structure JS
+
+- On component select: fetch/show percent; force amount `0`; amount read-only for those rows.
+
+### 4. Slip server — `calculate_salary_slip_amounts_exact`
+
+After earnings loop (and thus after Additional Salary rows already on `earnings`):
+
+```text
+for deduction row:
+  if component.percent_on_total_earning:
+    amount = flt(max(total_earnings, 0) * percent / 100, digits)
+  elif PT: ...
+  else: existing logic
+```
+
+Do **not** apply payment-day proration on top.
+
+### 5. Slip client — `apply_attendance`
+
+Same branch as server (load percent from component or child field). Keep Amount read-only for these rows.
+
+### 6. Tests (minimum)
+
+| Case | Expect |
+|------|--------|
+| Earnings 50k + Additional 5k, 10% component | Deduction 5500 |
+| Two components 10% + 2% | Both on same slip |
+| Total earnings 0 | Deduction 0 |
+| Mutual exclusion flags | Throw on save |
+| SSA references component | Cannot change % / uncheck |
+| All SSAs cancelled/deleted | Can change % again |
+| SSA preview | Amount = SSA gross × % |
+
+## Tracer
+
+1. Spec commit
+2. Fields + component validation + lock
+3. Slip server calc + unit test (50k+5k → 10%)
+4. SSA preview + Structure % display
+5. Slip client parity + read-only amount
+
+## Progress log
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Grill / spec | done | |
+| Tracer fields + slip calc | pending | |
+| SSA / Structure UI | pending | |
+| Client parity + tests | pending | |

--- a/specs/009-percent-of-total-earning.md
+++ b/specs/009-percent-of-total-earning.md
@@ -136,6 +136,6 @@ Same branch as server (load percent from component or child field). Keep Amount 
 | Phase | Status | Notes |
 |-------|--------|-------|
 | Grill / spec | done | |
-| Tracer fields + slip calc | pending | |
-| SSA / Structure UI | pending | |
-| Client parity + tests | pending | |
+| Tracer fields + slip calc | done | Component fields, lock, server calc |
+| SSA / Structure UI | done | Preview % amount on SSA; Structure amount 0 |
+| Client parity + tests | done | Slip JS + 5 unit tests passing |

--- a/specs/PROGRESS.md
+++ b/specs/PROGRESS.md
@@ -11,6 +11,7 @@ Single board for all specs in this folder. New specs get the next number (`002-â
 | 005 | [Monthly Salary Register Compressed](./005-monthly-salary-register-compressed.md) | ready for review | Format filter + Desk/PDF/Excel UX polish |
 | 006 | [Additional-Only Salary Components](./006-additional-only-salary-components.md) | done | Link-only AS/AD; earnings_map by name; slip print; period lock = submitted slips |
 | 007 | [Data Cleansing](./007-data-cleansing.md) | in progress | v1 matrix+delete+log; v2 AS/AD, SSA, orphans, period lock |
+| 009 | [Percent of Total Earning](./009-percent-of-total-earning.md) | in progress | Component % deductions (94J/91Q style); SSA preview + slip calc |
 
 ## Status legend
 

--- a/specs/PROGRESS.md
+++ b/specs/PROGRESS.md
@@ -11,7 +11,7 @@ Single board for all specs in this folder. New specs get the next number (`002-â
 | 005 | [Monthly Salary Register Compressed](./005-monthly-salary-register-compressed.md) | ready for review | Format filter + Desk/PDF/Excel UX polish |
 | 006 | [Additional-Only Salary Components](./006-additional-only-salary-components.md) | done | Link-only AS/AD; earnings_map by name; slip print; period lock = submitted slips |
 | 007 | [Data Cleansing](./007-data-cleansing.md) | in progress | v1 matrix+delete+log; v2 AS/AD, SSA, orphans, period lock |
-| 009 | [Percent of Total Earning](./009-percent-of-total-earning.md) | in progress | Component % deductions (94J/91Q style); SSA preview + slip calc |
+| 009 | [Percent of Total Earning](./009-percent-of-total-earning.md) | in progress | Implemented on `feat/percent-of-total-earning`; tests passing |
 
 ## Status legend
 


### PR DESCRIPTION
## Why?

HR needs deductions like 94J @ 10% and 91Q @ 2% of Total Earnings without a formula engine.

## What?

- Salary Component: **% on Total Earning** + percent (1–100)
- Slip amount = final Total Earnings (after proration, including Additional Salary) × %
- SSA shows read-only % and preview amount from SSA gross
- Structure shows read-only %; amount stays 0
- Percent / checkbox locked while any non-cancelled SSA references the component

## How?

See `specs/009-percent-of-total-earning.md`. Unit tests cover 10% with additional salary, two rates, zero earnings, mutual exclusion, and SSA lock.


Made with [Cursor](https://cursor.com)