### PR TITLE
fix: restore Employee Loan DocType after scrap patch

### DIFF
--- a/saral_hr/patches.txt
+++ b/saral_hr/patches.txt
@@ -14,6 +14,7 @@ saral_hr.patches.seed_additional_only_salary_components
 saral_hr.patches.ensure_data_cleansing_workspace_link
 saral_hr.patches.migrate_employee_loan_advance_split
 saral_hr.patches.scrap_legacy_loan_module
+saral_hr.patches.restore_employee_loan_doctypes
 saral_hr.patches.ensure_employee_loan_workspace
 saral_hr.patches.ensure_loan_ledger_workspace_links
 saral_hr.patches.dedupe_employee_loan_dues

--- a/saral_hr/patches/restore_employee_loan_doctypes.py
+++ b/saral_hr/patches/restore_employee_loan_doctypes.py
@@ -1,0 +1,13 @@
+"""Restore Employee Loan DocTypes if scrap_legacy_loan_module removed them."""
+
+import frappe
+
+
+def execute():
+	# Child first, then parent, then standalone Due.
+	for dn in (
+		"employee_loan_prepayment",
+		"employee_loan",
+		"employee_loan_due",
+	):
+		frappe.reload_doc("saral_hr", "doctype", dn, force=True)

--- a/saral_hr/patches/scrap_legacy_loan_module.py
+++ b/saral_hr/patches/scrap_legacy_loan_module.py
@@ -11,8 +11,9 @@ REPORTS = [
 ]
 
 # Parents first, then children (force also handles orphans).
+# Do NOT delete "Employee Loan" — the new loan register reuses that DocType name.
+# Deleting it after model sync leaves Salary Details.loan pointing at a missing DocType.
 DOCTYPES = [
-	"Employee Loan",
 	"Employee Advance",
 	"Employee Loan Advance",
 	"Employee Loan Schedule",


### PR DESCRIPTION
## Problem
Production migrate ran `scrap_legacy_loan_module`, which deleted DocType **Employee Loan** after model sync. `Salary Details.loan` still links to it, so Desk fails everywhere with: Field loan is referring to non-existing doctype Employee Loan.

## Solution
- Stop deleting `Employee Loan` in the scrap patch (new register reuses that name).
- Add `restore_employee_loan_doctypes` so migrate reloads Loan / Prepayment / Due.

## Test plan
- [ ] Deploy and run `bench --site <site> migrate` + `clear-cache`
- [ ] Confirm error gone on Salary Slip / Desk
- [ ] Confirm Employee Loan DocType exists


Made with [Cursor](https://cursor.com)